### PR TITLE
Proposal: Refreshed WCAG 2.2 Complaint Navigation

### DIFF
--- a/source/_static/nav-collapse.css
+++ b/source/_static/nav-collapse.css
@@ -1,0 +1,84 @@
+.bd-sidebar-primary .sidebar-primary-item {
+  --toc-text: #4a5a73;
+  --toc-text-strong: #1f2937;
+  --toc-accent: #0d7f91;
+}
+
+.bd-sidebar-primary .sidebar-primary-item li.has-children {
+  position: relative;
+  display: block;
+}
+
+.bd-sidebar-primary .sidebar-primary-item ul {
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0;
+}
+
+.bd-sidebar-primary .sidebar-primary-item li {
+  margin: 0.2rem 0;
+}
+
+.bd-sidebar-primary .sidebar-primary-item h3,
+.bd-sidebar-primary .sidebar-primary-item h3 a {
+  color: var(--toc-text-strong);
+  font-weight: 700;
+}
+
+.bd-sidebar-primary .sidebar-primary-item li.has-children > .nav-collapse-toggle {
+  border: 0;
+  background: transparent;
+  color: var(--toc-text);
+  cursor: pointer;
+  margin-right: 0.25rem;
+  padding: 0.1rem 0.2rem;
+  line-height: 1;
+  font-size: 0.85rem;
+  vertical-align: middle;
+}
+
+.bd-sidebar-primary .sidebar-primary-item li.has-children > .nav-collapse-toggle::before {
+  content: "▸";
+  display: inline-block;
+}
+
+.bd-sidebar-primary .sidebar-primary-item li.has-children > .nav-collapse-toggle[aria-expanded="true"]::before {
+  content: "▾";
+}
+
+/* Keep text alignment consistent between rows with and without dropdown toggles. */
+.bd-sidebar-primary .sidebar-primary-item li:not(.has-children) > a {
+  padding-left: 1.35rem;
+}
+
+/* Remove underlines in the left table-of-contents links. */
+.bd-sidebar-primary .sidebar-primary-item a {
+  color: var(--toc-text);
+  text-decoration: none !important;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.bd-sidebar-primary .sidebar-primary-item a:hover,
+.bd-sidebar-primary .sidebar-primary-item a:focus {
+  color: var(--toc-text-strong);
+  text-decoration: none !important;
+}
+
+.bd-sidebar-primary .sidebar-primary-item li.current > a {
+  color: var(--toc-accent);
+  font-weight: 700;
+}
+
+.bd-sidebar-primary .sidebar-primary-item li.current {
+  border-left: 4px solid var(--toc-accent);
+  padding-left: 0.5rem;
+}
+
+/* Keep top header controls (search/theme) right-aligned on desktop. */
+@media (min-width: 992px) {
+  .bd-header .navbar-header-items {
+    display: flex;
+    justify-content: flex-end;
+  }
+}

--- a/source/_static/nav-collapse.js
+++ b/source/_static/nav-collapse.js
@@ -1,0 +1,52 @@
+(function () {
+  function initSidebarCollapse() {
+    var sidebar = document.querySelector('.bd-sidebar-primary');
+    if (!sidebar) return;
+
+    var rootLists = sidebar.querySelectorAll('.sidebar-primary-item > ul, .sidebar-primary-item nav ul');
+    if (!rootLists.length) return;
+
+    rootLists.forEach(function (rootList) {
+      rootList.querySelectorAll('li').forEach(function (li) {
+        var childList = Array.from(li.children).find(function (el) {
+          return el.tagName && el.tagName.toLowerCase() === 'ul';
+        });
+        var link = Array.from(li.children).find(function (el) {
+          return el.tagName && el.tagName.toLowerCase() === 'a';
+        });
+
+        if (!childList || !link) return;
+        if (li.querySelector(':scope > .nav-collapse-toggle')) return;
+
+        li.classList.add('has-children');
+
+        var toggle = document.createElement('button');
+        toggle.className = 'nav-collapse-toggle';
+        toggle.type = 'button';
+        toggle.setAttribute('aria-label', 'Toggle submenu');
+
+        var isCurrentBranch = li.classList.contains('current') || !!li.querySelector('.current');
+        var expanded = isCurrentBranch;
+
+        toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        if (!expanded) {
+          childList.hidden = true;
+        }
+
+        toggle.addEventListener('click', function () {
+          var nowExpanded = toggle.getAttribute('aria-expanded') !== 'true';
+          toggle.setAttribute('aria-expanded', nowExpanded ? 'true' : 'false');
+          childList.hidden = !nowExpanded;
+        });
+
+        li.insertBefore(toggle, link);
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initSidebarCollapse);
+  } else {
+    initSidebarCollapse();
+  }
+})();

--- a/source/_templates/globaltoc.html
+++ b/source/_templates/globaltoc.html
@@ -1,0 +1,11 @@
+{# Custom global TOC sidebar: show only page entries, not in-page section anchors. #}
+{% set toctree_html = toctree(
+    maxdepth=6,
+    collapse=False,
+    includehidden=True,
+    titles_only=True
+) %}
+{% if toctree_html %}
+<h3><a href="{{ pathto(master_doc) }}">Table of Contents</a></h3>
+{{ toctree_html }}
+{% endif %}

--- a/source/conf.py
+++ b/source/conf.py
@@ -36,14 +36,26 @@ html_show_sourcelink = False
 html_theme_options = {
     "navigation_with_keys": True,
     "use_edit_page_button": True,
-    "navbar_end": ["theme-switcher"],
+    # Keep the header minimal: branding + utilities only.
+    "navbar_start": ["navbar-logo"],
+    "navbar_center": [],
+    "navbar_end": ["search-button", "theme-switcher"],
+    # Expand navigation in the left sidebar so top-level sections are visible.
+    "show_nav_level": 3,
+    # Keep section trees visible in the sidebar (collapsible), instead of
+    # collapsing everything to the current page context.
+    "collapse_navigation": False,
     "logo": {
         "text": "Momentum Training",
         },
-    "footer_center": ["show-accessibility"]
+    "footer_center": ["show-accessibility"],
+    # Remove the right-side "On this page" panel globally.
+    "secondary_sidebar_items": []
 }
 
 html_sidebars = {
+    # Use a global site navigation tree on the left for all pages.
+    "**": ["globaltoc.html"],
     "index": []
 }
 
@@ -61,3 +73,5 @@ html_context = {
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ['_static']
+html_css_files = ['nav-collapse.css']
+html_js_files = ['nav-collapse.js']

--- a/source/index.rst
+++ b/source/index.rst
@@ -29,7 +29,7 @@ Contents of the training course
 -------------------------------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 3
 
    introduction/index.rst
    mesh_overview/index.rst

--- a/source/introduction/index.rst
+++ b/source/introduction/index.rst
@@ -10,6 +10,10 @@ This module provides an introduction to the LFRic Atmosphere model and the Momen
    * To be aware of
    * To become familiar with
 
-.. include:: seamless_modelling.rst
-.. include:: components.rst
-.. include:: history_context.rst
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents
+
+   seamless_modelling.rst
+   components.rst
+   history_context.rst

--- a/source/lfric_infrastructure/index.rst
+++ b/source/lfric_infrastructure/index.rst
@@ -12,8 +12,12 @@ on the LFRic Atmosphere model and its underlying components.
    * To become familiar with working practises required for model development.
 
 
-.. include:: science_apps.rst
-.. include:: code_repositories.rst
-.. include:: psykal_infrastructure.rst
-.. include:: working_practices.rst
-.. include:: practical_exercises.rst
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents
+
+   science_apps.rst
+   code_repositories.rst
+   psykal_infrastructure.rst
+   working_practices.rst
+   practical_exercises.rst


### PR DESCRIPTION
## Proposed: Left-Side Navigation / Table of Contents Structure

### Status
This is a **proposed** navigation update for review.  
If maintainers prefer a different structure or interaction pattern, this can be adjusted but I felt it was worth highlighting. 

## Navigation Behaviour (Proposed)
- Keep one persistent left-side TOC for all pages.
- Use collapsible sections for module/page groups.
- Show page-level entries only in TOC (not in-page heading anchors).
- Remove right-side “On this page” panel for a simpler single-navigation model.
- Keep search in the top header.

---

## Accessibility Rationale (WCAG 2.2)

WCAG: Web Content Accessibility Guidelines: https://www.w3.org/WAI/standards-guidelines/wcag/ 

This proposal is intended to improve accessibility and consistency. It is not presented as an automatic compliance guarantee, but as a structure that better supports WCAG outcomes.

### Relevant WCAG 2.2 Success Criteria (supporting)
- 1.3.1 Info and Relationships: Clear hierarchy in the navigation reflects information structure.
- 2.4.5 Multiple Ways: Users can navigate by persistent TOC and search.
- 2.4.6 Headings and Labels: Navigation labels are explicit and section-oriented.
- 2.4.8 Location (AAA): Persistent sidebar helps users maintain orientation.
- 3.2.3 Consistent Navigation: Same navigation pattern across all pages.
- 2.4.7 Focus Visible and 2.4.11 Focus Not Obscured (Minimum): Single-column nav layout reduces focus loss/obscuring risk in multi-panel layouts.
- 2.5.8 Target Size (Minimum): Collapsible controls can be styled to maintain adequate click/tap targets.

---

## General Benefits
- Reduces cognitive load by keeping one predictable navigation area.
- Makes it easier for learners to see scope and progression.
- Reduces ambiguity around where content lives.
- Improves discoverability of individual training pages.
- Simplifies responsive/mobile behaviour by avoiding competing side panels.

---

## Maintainer Choice / Flexibility
This is intentionally a proposal.

If this exact structure is not preferred, we can:
- adjust depth (e.g. fewer or more nested pages),
- rename section labels,
- keep or restore specific right-side elements,
- tune the visual style to align with project branding.

Happy to iterate based on reviewer feedback, but do feel strongly that the current navigation setup for the course is quite damaging to accessibility and best practice in this dimension generally. 

Screenshot of proposed website: 

<img width="1408" height="925" alt="proposed_table_of_content_navigation" src="https://github.com/user-attachments/assets/3ebfd6ff-9749-462b-bae9-6dd279169e6b" />

