### PR TITLE
Add optional Pixi workflow and docs CI

### DIFF
--- a/.github/workflows/build_docs_pixi.yml
+++ b/.github/workflows/build_docs_pixi.yml
@@ -1,0 +1,27 @@
+name: Build documentation with Pixi
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          pixi-version: v0.67.1
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+
+      - name: Build documentation
+        run: pixi run clean-html

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.bat
 *.lock
 .venv/
+.pixi/
 data-tutorials/
 build
 build/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,148 @@
+# AGENTS.md
+
+## Purpose
+
+This repository publishes the LFRic Atmosphere self-learning training site.
+It is primarily a Sphinx documentation project with a bundled copy of the
+`iris-mesh-tutorial` notebooks for learner delivery.
+
+## Repository map
+
+- `README.md`: contributor setup, dependency policy, and the canonical local
+  build instructions.
+- `pyproject.toml`: reference dependency manifest for the `uv` workflow and CI.
+  This repository is not currently installable as a Python library. Do not add
+  `requirements.txt` files or commit lockfiles here.
+- `pixi.toml`: completely optional conda-first alternative environment
+  definition. Keep it aligned with the docs and notebook stack when relevant,
+  but treat `uv` as the reference workflow unless the user explicitly asks to
+  prefer Pixi.
+- `Makefile`: thin wrapper around `sphinx-build -M ...`.
+- `source/`: Sphinx documentation sources.
+- `source/index.rst`: root toctree for the published training site.
+- `source/conf.py`: Sphinx extensions, theme settings, GitHub edit links, and
+  custom static assets.
+- `source/_static/`: images, CSS, JS, and video referenced by the docs.
+- `source/_templates/`: custom sidebar/footer templates.
+- `notebooks/iris-mesh-tutorial/`: local training-delivery copy of the upstream
+  `scitools-classroom/iris-mesh-tutorial` project.
+- `.github/workflows/deploy_pages.yml`: CI path used for the published site.
+
+## Environment and setup
+
+- Supported Python is `>=3.11,<3.13`; GitHub Pages CI currently builds with
+  Python `3.11`.
+- Preferred docs setup:
+
+  ```bash
+  uv sync --python 3.11
+  source .venv/bin/activate
+  ```
+
+- Optional Pixi setup:
+
+  ```bash
+  pixi install
+  pixi run html
+  ```
+
+- Optional extras are defined in `pyproject.toml`:
+  - `dev` for contributor tooling such as `pre-commit`
+  - `notebooks` for local notebook work
+  - `mesh_tutorials` for the bundled mesh tutorial workflow
+- `pixi.toml` intentionally flattens these into one optional environment
+  instead of mirroring the `pyproject.toml` extras one-for-one. Keep the
+  matching version constraints aligned across the two files when relevant.
+- Some matching constraints are written differently because the tools use
+  different version-spec syntaxes. In particular, Pixi / Conda-style entries
+  such as `0.5.3.*` and `1.14.4.*` are the tooling-compatible form of the same
+  effective pin represented in `pyproject.toml` as `==0.5.3` and `==1.14.4`;
+  treat that as a syntax difference, not a real environment difference.
+- Although `pyproject.toml` contains `[project]` metadata, the repository is
+  not currently an installable Python package. Do not recommend
+  `pip install .` or `pip install -e .` as the normal setup route.
+- The mesh tutorial regridding practicals need `esmpy`. The repository
+  currently references it in `notebooks/README.md`, the bundled mesh tutorial
+  setup instructions, `source/mesh_overview/exercises/practical_exercises.rst`,
+  and the Pixi `mesh-import-check` task. GitHub Pages CI does not install or
+  use `esmpy`; the deploy workflow still builds with `uv sync` and
+  `uv run make clean html`.
+- The regridding package name differs by ecosystem: use `esmf-regrid` for the
+  PyPI / `pyproject.toml` dependency and `iris-esmf-regrid` for the Conda /
+  `pixi.toml` dependency.
+- `sphinxcontrib-quizdown` is not available on conda-forge. Keep it under
+  Pixi's `[pypi-dependencies]` as a Git-sourced package rather than moving it
+  into `[dependencies]`.
+- Dependency policy in `README.md` is explicit: `uv` remains the reference
+  workflow, while `pixi.toml` is an optional alternative.
+
+## Editing guidance
+
+- Keep changes learner-focused and introductory. The audience is new to LFRic
+  Atmosphere and related workflows.
+- Most content is authored in reStructuredText. Preserve heading hierarchy,
+  directive indentation, and existing toctree structure.
+- When adding or moving pages, update the relevant `index.rst` or other
+  containing toctree so the page is reachable in the built site.
+- Put new images or downloadable static assets in `source/_static/` and
+  reference them from the relevant `.rst` page.
+- If you change navigation or page chrome, inspect the full set of related
+  files together:
+  - `source/conf.py`
+  - `source/_templates/globaltoc.html`
+  - `source/_templates/show-accessibility.html`
+  - `source/_static/nav-collapse.css`
+  - `source/_static/nav-collapse.js`
+- Notebook content under `notebooks/iris-mesh-tutorial/notebooks/` is stored as
+  plain `.ipynb` files, not as paired Jupytext sources.
+- Keep notebook diffs tight. Avoid unnecessary execution-count churn or large
+  output blobs unless the output is intentionally part of the training
+  material.
+- Helper code for the mesh tutorial lives under
+  `notebooks/iris-mesh-tutorial/notebooks/support/`.
+- The mesh tutorial copy is downstream training material. Keep LFRic-specific
+  adaptations in this repository, but treat generic improvements as upstream
+  candidates for `scitools-classroom/iris-mesh-tutorial`.
+
+## Validation
+
+- Standard local validation for doc changes:
+
+  ```bash
+  uv run make clean html
+  ```
+
+- Useful extra checks when touching RST structure or links:
+
+  ```bash
+  uv run sphinx-lint source
+  uv run make linkcheck
+  ```
+
+- The deployed site is built from `main` by GitHub Actions using:
+
+  ```bash
+  uv sync
+  uv run make clean html
+  ```
+
+- For notebook changes, there is no dedicated notebook CI in this repository.
+  Smoke-test the changed notebook or helper code locally where practical.
+- For the mesh tutorial, launch Jupyter from
+  `notebooks/iris-mesh-tutorial/notebooks/` so local paths and imports match
+  the training instructions.
+
+## Working norms for agents
+
+- Prefer small, reviewable documentation edits over broad rewrites.
+- Match existing terminology: "Momentum", "LFRic Atmosphere", "science
+  configurations", and "working practices" all have established meanings in the
+  training content.
+- Do not change dependency-management conventions casually. If new dependencies
+  are necessary, update `pyproject.toml` and keep the README setup instructions
+  consistent with that change. If the change also affects the optional Pixi
+  environment, update `pixi.toml` too.
+- Do not add packaging boilerplate or treat this repository as a distributable
+  Python library unless the user explicitly asks for that change.
+- Do not commit generated `build/` output, virtual environments, or notebook
+  checkpoint files; those are already ignored.

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ git branch -D main
 
 ### Development Environment
 
-Dependencies are defined in `pyproject.toml`.
-This repository uses that file as the dependency manifest for the documentation
-and notebook environment. It is not currently installable as a Python library,
-so contributor setup should use `uv` rather than `pip install .` or
+The reference contributor environment is defined in `pyproject.toml` and
+managed with `uv`.
+This repository is not currently installable as a Python library, so
+contributor setup should use `uv` rather than `pip install .` or
 `pip install -e .`.
 
 #### `uv` setup (recommended)
@@ -90,13 +90,49 @@ source .venv/bin/activate
 
 If you prefer not to activate the environment, run commands with `uv run ...` instead.
 
+#### `pixi` setup (completely optional alternative)
+
+If you prefer a conda-first workflow, the repository also provides a
+`pixi.toml` manifest. This is a completely optional alternative setup. The
+`uv` workflow above remains the reference contributor path and the one mirrored
+by the GitHub Pages deploy workflow. A separate build-only GitHub Actions
+workflow also exercises the Pixi path.
+
+The Pixi environment is intentionally flat: it installs the documentation,
+notebook, mesh tutorial, and development tooling dependencies together in one
+environment, using conda-forge packages where available. The current
+`pixi.toml` targets the standard Linux, macOS, and Windows platforms.
+
+Install `pixi` if needed, then create the environment:
+
+```bash
+pixi install
+```
+
+Run the common checks:
+
+```bash
+pixi run html
+pixi run clean-html
+pixi run lint
+pixi run linkcheck
+```
+
+Use `pixi run html` for incremental rebuilds and `pixi run clean-html` when you
+want the same clean HTML build used by the reference `uv` workflow.
+
 ### Dependency Policy
 
-- Build environments from `pyproject.toml` only.
-- Treat `pyproject.toml` as an environment/dependency manifest for this
-  repository, not as a signal that the repository is a distributable Python
-  package.
-- If dependency updates are needed, update constraints in `pyproject.toml` and recreate the environment with your selected setup route.
+- `uv` with `pyproject.toml` remains the reference workflow for contributors
+  and the GitHub Pages deploy workflow.
+- `pixi.toml` is a completely optional alternative environment definition.
+  Keep it working when dependency changes affect the docs or notebook stack;
+  the repository also has a build-only GitHub Actions workflow that exercises
+  this path.
+- Treat these files as environment manifests for this repository, not as a
+  signal that the repository is a distributable Python package.
+- If dependency updates are needed, update constraints in `pyproject.toml` and,
+  when relevant, the corresponding entries in `pixi.toml`.
 
 ### Building Training Materials
 
@@ -105,12 +141,19 @@ The training materials are based on [Sphinx](https://www.sphinx-doc.org) and can
 To build the LFRic Atmosphere training materials in HTML format run the following command:
 
 ```bash
-# If you are using uv without activating .venv:
+# Reference uv workflow without activating .venv:
 uv run make clean html
 
 # If you have already activated .venv:
 make clean html
+
+# Optional pixi alternatives:
+pixi run clean-html
+pixi run html
 ```
+
+With Pixi, `clean-html` matches the clean build above and `html` keeps the
+faster incremental rebuild path.
 
 That concludes the process! You’ll find the generated HTML files within the “build” folder.
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,43 @@
+[workspace]
+name = "lfric-atmosphere-training"
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
+
+[tasks]
+help = { cmd = "make help", description = "List available Sphinx make-mode targets." }
+clean = { cmd = "make clean", description = "Remove generated Sphinx build output." }
+html = { cmd = "make html", description = "Build HTML docs incrementally without cleaning first." }
+clean-html = { cmd = "make clean html", description = "Build HTML docs from a clean Sphinx output directory." }
+linkcheck = { cmd = "make linkcheck", description = "Check external links with Sphinx's built-in linkcheck builder." }
+lint = { cmd = "sphinx-lint source", description = "Run sphinx-lint against the documentation sources." }
+lab = { cmd = "jupyter lab", cwd = "notebooks/iris-mesh-tutorial/notebooks", description = "Launch JupyterLab in the bundled mesh tutorial notebooks directory." }
+install-kernel = { cmd = '''python -m ipykernel install --user --name lfric-mesh --display-name "Python (lfric-mesh)"''', description = "Install the Pixi Python environment as a Jupyter kernel named lfric-mesh." }
+mesh-import-check = { cmd = '''python -c "import esmf_regrid, esmpy; print('mesh ok')"''', description = "Verify the mesh tutorial regridding imports are available." }
+
+[dependencies]
+python = ">=3.11,<3.13"
+sphinx = ">=7,<9"
+pydata-sphinx-theme = "*"
+sphinx-toolbox = "<4"
+sphinxcontrib-video = "*"
+sphinx-lint = "*"
+make = "*"
+jupyterlab = "*"
+scitools-iris = "*"
+geovista = "0.5.3.*"
+pyvista = ">=0.46.3,<0.47"
+vtk = "<9.6"
+ipyvtklink = "*"
+trame = "*"
+trame-vtk = "*"
+trame-vuetify = "*"
+jupyter-server-proxy = "*"
+matplotlib = "*"
+jupytext = "1.14.4.*"
+iris-esmf-regrid = "*"
+numpy = "<2"
+pre-commit = "*"
+esmpy = "*"
+
+[pypi-dependencies]
+sphinxcontrib-quizdown = { git = "https://github.com/bonartm/sphinxcontrib-quizdown.git" }


### PR DESCRIPTION
TL;DR this PR uses a stacking PR workflow and should be merged only after #144 is merged.

## Summary
- add `pixi.toml` and ignore the local `.pixi/` workspace state
- document Pixi in `README.md` as a completely optional, conda-first alternative to the reference `uv` workflow
- add a GitHub Actions workflow that exercises the Pixi docs build

## Why
This keeps `uv` as the reference contributor and Pages workflow while adding a working Pixi path with CI coverage.

## Stack
- base PR: #144

## Validation
- `uv run make clean html`
- `pixi run clean-html`
