### PR TITLE
Enable numfig and add figure labels to introduction section

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -27,6 +27,9 @@ extensions = ['pydata_sphinx_theme',
 templates_path = ['_templates']
 exclude_patterns = []
 
+# -- Figure numbering --------------------------------------------------------
+numfig = True
+
 # -- layout -----------------------------------------------------------------
 # https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#
 

--- a/source/introduction/components.rst
+++ b/source/introduction/components.rst
@@ -3,6 +3,8 @@ Components, Science Configurations, and Systems
 
 Components of the `Momentum  <https://www.metoffice.gov.uk/research/approach/modelling-systems/momentum>`_ Framework, like the atmospheric model LFRic Atmosphere, are combined to prediction and projection systems, like the ones mentioned in the graphic in the seamless modelling section. Science Configurations are rigorously tested  and define the exact setup for the individual model components. These configurations are distinguished between regional and global configurations. Additionally, there are coupled Science Configurations which detail multi-model setups, e.g. an atmosphere - ocean model.
 
+.. _fig-intro-components:
+
 .. figure:: /_static/1/intro_components.png
    :width: 650px
    :alt: Components of prediction and projection systems

--- a/source/introduction/history_context.rst
+++ b/source/introduction/history_context.rst
@@ -5,6 +5,8 @@ LFRic Atmosphere has been `developed <https://www.metoffice.gov.uk/research/news
 
 LFRic Atmosphere uses the same terrain-following vertical coordinates as the Unified Model but has a cubed sphere mesh, a new mixed finite-element dynamical core, GungHo, and a new coding infrastructure. The cubed sphere mesh avoids the pole singularity problem of longitude–latitude grids which prohibits scaling the Unified Model to km-scale global grids. The coding infrastructure separates details of code parallelisation from the mathematical formulation of the physical representation of the atmosphere. This separation of concerns allows for easier optimisation of the same model code for different compute platforms.
 
+.. _fig-intro-mesh-vertical:
+
 .. figure:: /_static/1/lfric_mesh_and_vertical_grid.png
    :width: 650px
    :alt: lfric mesh and vertical grid

--- a/source/introduction/seamless_modelling.rst
+++ b/source/introduction/seamless_modelling.rst
@@ -5,6 +5,8 @@ Seamless Modelling
 
 Since the 1990's the Met Office strategy has been to develop a single model family used for prediction across a range of timescales. This means the same dynamical core and, where possible, the same parameterization schemes are used across a broad range of spatial and temporal scales. The image below shows Met Office prediction and projection systems configured for applications on different scales, ranging from a few days to hundreds of years.
 
+.. _fig-intro-seamless:
+
 .. figure:: /_static/1/intro_seamless.png
    :width: 650px
 


### PR DESCRIPTION
## Summary
- Enable Sphinx `numfig = True` in `source/conf.py` for automatic figure numbering
- Add cross-reference labels (`fig-intro-components`, `fig-intro-seamless`, `fig-intro-mesh-vertical`) to the three figures in the introduction section
- Part of #122 (Figure Labelling and Referencing)

## Test plan
- [x] Sphinx build succeeds with `numfig = True`
- [x] All three introduction figures display `Fig. N` numbering in HTML output
- [ ] Remaining sections will be labelled in subsequent units