### PR TITLE
Add figure labels to LFRic infrastructure section

### DIFF
--- a/source/lfric_infrastructure/practical_standart_suite.rst
+++ b/source/lfric_infrastructure/practical_standart_suite.rst
@@ -50,6 +50,8 @@ For other platforms, chose appropriate alternative workflow IDs.
    * Creates a low-resolution C12 mesh as input for the model
 
 
+.. _fig-infra-standard-suite:
+
 .. figure:: /_static/3/lfric_apps_standard_suite.svg
   :width: 400px
 

--- a/source/lfric_infrastructure/practical_stem_test.rst
+++ b/source/lfric_infrastructure/practical_stem_test.rst
@@ -15,6 +15,8 @@ Before running integration tests, it's important to document your changes and ma
 
 Start with `creating a ticket <https://metoffice.github.io/simulation-systems/WorkingPractices/working_practices.html>`_ by opening a `new ticket <https://code.metoffice.gov.uk/trac/lfric_apps/newticket>`_ on the LFRic Apps GitHub to document your model experiment.
 
+.. _fig-infra-rose-stem-ticket:
+
 .. figure:: /_static/3/practical_rose_stem_ticket.png
   :width: 625px
 

--- a/source/lfric_infrastructure/psykal_infrastructure.rst
+++ b/source/lfric_infrastructure/psykal_infrastructure.rst
@@ -12,6 +12,8 @@ The software architecture that enables this is called `PSyKAl <https://psyclone.
 
 Scientific operations on full fields are implemented in the Algorithm layer. Kernels specify operations for vertical columns. Parallelism is implemented in the Parallel System layer which is auto generated with a tool called `PSyclone <https://psyclone.readthedocs.io/en/stable/>`_.
 
+.. _fig-infra-psykal:
+
 .. figure:: /_static/psykal.png
   :width: 650px
 

--- a/source/lfric_infrastructure/working_practices.rst
+++ b/source/lfric_infrastructure/working_practices.rst
@@ -5,6 +5,8 @@ Working Practices
 
 Developers for LFRic Atmosphere need to know the `Simulation Systems Working Practices <https://metoffice.github.io/simulation-systems>`_, which detail the development cycle and process. The `Working Practices <https://metoffice.github.io/simulation-systems/WorkingPractices/working_practices.html>`_ pages provide instructions for `ticketing <https://metoffice.github.io/simulation-systems/WorkingPractices/tickets.html>`_, `branching <https://metoffice.github.io/simulation-systems/WorkingPractices/branches.html>`_, `developing <https://metoffice.github.io/simulation-systems/WorkingPractices/developing_change.html>`_, working with `multiple repositories <https://       metoffice.github.io/simulation-systems/WorkingPractices/multi_repository.html>`_, `testing <https://metoffice.github.io/simulation-systems/WorkingPractices/testing.html>`_, and passing the code and science `reviews <https:// metoffice.github.io/simulation-systems/WorkingPractices/reviews.html>`_.
 
+.. _fig-infra-working-practices:
+
 .. figure:: /_static/working_practices.jpg
   :width: 650px
 


### PR DESCRIPTION
## Summary
- Add labels to 4 figures across working_practices, psykal_infrastructure, practical_stem_test, and practical_standart_suite
- Part of #122

## Test plan
- [ ] Build docs with `make html` and verify figure numbering appears