### PR TITLE
Convert images to figures and add labels in modelling section

### DIFF
--- a/source/modelling/gc_practical_exercises/plotting/plotting.rst
+++ b/source/modelling/gc_practical_exercises/plotting/plotting.rst
@@ -11,5 +11,9 @@ Plotting your data
 * Run the script
 
 
-.. image:: /_static/plotting.png
+.. _fig-model-plotting:
+
+.. figure:: /_static/plotting.png
    :width: 650px
+
+   Plotting output from a GC practical exercise.

--- a/source/modelling/introduction/core_models/core_models.rst
+++ b/source/modelling/introduction/core_models/core_models.rst
@@ -26,6 +26,8 @@ For example, in the Global Coupled (GC) approach, certain components are strongl
 
 The diagram below illustrates coupling components in the GC approach.
 
+.. _fig-model-gc-components:
+
 .. figure:: /_static/components.png
    :width: 650px
    :alt: components in a GC-LFRic configuration

--- a/source/modelling/introduction/index.rst
+++ b/source/modelling/introduction/index.rst
@@ -18,5 +18,9 @@ Science configurations are constructed from component models, each of which repr
 
 This chapter first introduces the component models used within the Momentum framework and explains how they are coupled. It then describes the concept of science configurations, their testing and release process, and their role in supporting seamless modelling across research and operational applications.
 
-.. image:: /_static/seamless_modelling.png
+.. _fig-model-seamless:
+
+.. figure:: /_static/seamless_modelling.png
    :width: 650px
+
+   Seamless modelling across spatial and temporal scales.

--- a/source/modelling/med/model_development.rst
+++ b/source/modelling/med/model_development.rst
@@ -16,8 +16,12 @@ The evaluation teams (regional known as RMED and global, GMED) have strong links
   
    * If interested, find the PEG or CoG lead on the GMED or RMED Met Office Science Repository Service (MOSRS) pages and contact them, or you can contact Momentum_Partnership@metoffice.gov.uk.
 
-.. image:: /_static/seamless_dev_cycle.png
+.. _fig-model-dev-cycle:
+
+.. figure:: /_static/seamless_dev_cycle.png
    :width: 650px
+
+   The seamless development cycle for Global Coupled configurations.
 
 In July 2022, the final UM-based GC configuration was released, 'GC5', before the implementation of the LFRic atmospheric model into GC configurations. LFRic atmosphere is the next-generation atmospheric model being developed by the Momentum framework, which is designed to be more modular and flexible than its predecessor.
 

--- a/source/modelling/med/model_evaluation.rst
+++ b/source/modelling/med/model_evaluation.rst
@@ -13,8 +13,12 @@ The Met Office maintains routine tools for validation of GC configurations:
 * `ESMValTool <https://esmvaltool.org/>`_
 * `MetPlus <https://dtcenter.org/community-code/metplus>`_
 
-.. image:: /_static/autoassess.png
+.. _fig-model-autoassess:
+
+.. figure:: /_static/autoassess.png
    :width: 700px
+
+   AutoAssess evaluation tools for model assessment.
 
 Regional evaluation tools
 -------------------------

--- a/source/modelling/tools/cylc/cylc.rst
+++ b/source/modelling/tools/cylc/cylc.rst
@@ -5,8 +5,12 @@ Cylc - workflow engine
 * Cylc workflows can be organized running tasks at specific clock cycles.
 * Cylc workflows represent the highest-level programming layer for organising the execution of our models, pre- and postprocessors.
 
-.. image:: /_static/cylc.gif
+.. _fig-model-cylc:
+
+.. figure:: /_static/cylc.gif
    :width: 700px
+
+   Cylc workflow visualisation.
 
 .. note::
    * Comprehensive guides and training for cylc can be found here: https://cylc.github.io/cylc-doc.


### PR DESCRIPTION
## Summary
- Convert 5 `.. image::` directives to `.. figure::` with captions so they are numbered by `numfig`
- Add labels to all 6 figures in the modelling section
- Part of #122

## Test plan
- [ ] Build docs with `make html` and verify figure numbering appears
- [ ] Verify converted figures display captions correctly