### PR TITLE
Add figure labelling and cross-referencing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 | GitHub user      | Real Name              | Affiliation           | Date       |
 | ---------------- | -----------------      | --------------------- | ---------- |
 | jcmt             | Joao Teixeira          | Met Office            | 2026-05-20 |
+| ickc             | Kolen Cheung           | University of Exeter  | 2026-05-20 |

--- a/source/conf.py
+++ b/source/conf.py
@@ -39,14 +39,7 @@ extensions = [
 ]
 
 templates_path = ['_templates']
-# These files are included by practical_exercises.rst. If Sphinx also
-# discovers them as standalone documents, labels inside the fragments are
-# registered twice and produce duplicate-label warnings.
-exclude_patterns = [
-    'lfric_infrastructure/practical_command_line.rst',
-    'lfric_infrastructure/practical_standard_suite.rst',
-    'lfric_infrastructure/practical_stem_test.rst',
-]
+exclude_patterns = []
 
 # -- Figure numbering --------------------------------------------------------
 numfig = True
@@ -71,7 +64,7 @@ def validate_figure_labelling(
 
     * a ``figure`` directive has no ``fig-*`` label;
     * a ``figure`` directive has no caption; or
-    * a ``figure`` directive has no alt text; or
+    * an image-backed ``figure`` directive has no alt text; or
     * an unallowlisted ``image`` directive remains outside a figure.
 
     ``unnumbered_images_by_doc`` intentionally defaults to an immutable narrow
@@ -104,7 +97,7 @@ def validate_figure_labelling(
                 f"{node_location(figure)}: figure for '{uri}' is missing "
                 'a caption.'
             )
-        if image is None or not image.get('alt', '').strip():
+        if image is not None and not image.get('alt', '').strip():
             errors.append(
                 f"{node_location(figure)}: figure for '{uri}' is missing "
                 'alt text.'

--- a/source/conf.py
+++ b/source/conf.py
@@ -2,6 +2,7 @@ import sys
 import os
 
 from docutils import nodes
+from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
 
 sys.path.append(os.path.abspath('../lib/'))
@@ -48,23 +49,21 @@ exclude_patterns = [
 # -- Figure numbering --------------------------------------------------------
 numfig = True
 
-UNNUMBERED_IMAGES_BY_DOC = {
-    'index': frozenset({'_static/momentum_logo.png'}),
-}
-
 
 def validate_figure_labelling(
-    app,
-    doctree,
+    app: Sphinx,
+    doctree: nodes.document,
     *,
-    unnumbered_images_by_doc=None,
-):
+    unnumbered_images_by_doc: dict[str, set[str]] = {
+        'index': {'_static/momentum_logo.png'},
+    },
+) -> None:
     """Enforce the site-wide figure labelling policy.
 
-    Issue #122 requires all content figures to have consistent numbering,
-    captions, cross-reference targets, and accessible descriptions. Sphinx can
-    number figures once ``numfig`` is enabled, but only if content uses
-    ``figure`` directives with explicit labels and captions.
+    Content figures should have consistent numbering, captions, cross-reference
+    targets, and accessible descriptions. Sphinx can number figures once
+    ``numfig`` is enabled, but only if content uses ``figure`` directives with
+    explicit labels and captions.
 
     This hook runs while Sphinx reads each doctree and fails the build when:
 
@@ -78,17 +77,15 @@ def validate_figure_labelling(
     and values are normalized image URIs.
     """
 
-    def node_location(node):
+    def node_location(node: nodes.Node) -> str:
         location = getattr(node, 'source', '<unknown source>')
         line = getattr(node, 'line', None)
         return f'{location}:{line}' if line else location
 
-    def image_uri(image):
+    def image_uri(image: nodes.image) -> str:
         return image.get('uri', '').lstrip('/')
 
-    errors = []
-    if unnumbered_images_by_doc is None:
-        unnumbered_images_by_doc = UNNUMBERED_IMAGES_BY_DOC
+    errors: list[str] = []
 
     for figure in doctree.findall(nodes.figure):
         image = next(figure.findall(nodes.image), None)
@@ -128,7 +125,7 @@ def validate_figure_labelling(
         raise ExtensionError(message)
 
 
-def setup(app):
+def setup(app: Sphinx) -> dict[str, str | bool]:
     """Register local Sphinx validation hooks."""
     app.connect('doctree-read', validate_figure_labelling)
     return {'version': '1.0', 'parallel_read_safe': True}

--- a/source/conf.py
+++ b/source/conf.py
@@ -48,28 +48,34 @@ exclude_patterns = [
 # -- Figure numbering --------------------------------------------------------
 numfig = True
 
+UNNUMBERED_IMAGES_BY_DOC = {
+    'index': frozenset({'_static/momentum_logo.png'}),
+}
+
+
 def validate_figure_labelling(
     app,
     doctree,
     *,
-    unnumbered_images_by_doc={'index': {'_static/momentum_logo.png'}},
+    unnumbered_images_by_doc=None,
 ):
     """Enforce the site-wide figure labelling policy.
 
     Issue #122 requires all content figures to have consistent numbering,
-    captions, and cross-reference targets. Sphinx can number figures once
-    ``numfig`` is enabled, but only if content uses ``figure`` directives with
-    explicit labels and captions.
+    captions, cross-reference targets, and accessible descriptions. Sphinx can
+    number figures once ``numfig`` is enabled, but only if content uses
+    ``figure`` directives with explicit labels and captions.
 
     This hook runs while Sphinx reads each doctree and fails the build when:
 
     * a ``figure`` directive has no ``fig-*`` label;
     * a ``figure`` directive has no caption; or
+    * a ``figure`` directive has no alt text; or
     * an unallowlisted ``image`` directive remains outside a figure.
 
     ``unnumbered_images_by_doc`` intentionally defaults to a narrow allowlist
     for decorative images that should not be numbered. Keys are Sphinx docnames
-    and values are image URIs as they appear in the doctree.
+    and values are normalized image URIs.
     """
 
     def node_location(node):
@@ -81,6 +87,8 @@ def validate_figure_labelling(
         return image.get('uri', '').lstrip('/')
 
     errors = []
+    if unnumbered_images_by_doc is None:
+        unnumbered_images_by_doc = UNNUMBERED_IMAGES_BY_DOC
 
     for figure in doctree.findall(nodes.figure):
         image = next(figure.findall(nodes.image), None)
@@ -96,6 +104,11 @@ def validate_figure_labelling(
             errors.append(
                 f"{node_location(figure)}: figure for '{uri}' is missing "
                 'a caption.'
+            )
+        if image is None or not image.get('alt', '').strip():
+            errors.append(
+                f"{node_location(figure)}: figure for '{uri}' is missing "
+                'alt text.'
             )
 
     for image in doctree.findall(nodes.image):

--- a/source/conf.py
+++ b/source/conf.py
@@ -52,7 +52,7 @@ def validate_figure_labelling(
     app,
     doctree,
     *,
-    unnumbered_images_by_doc=None,
+    unnumbered_images_by_doc={'index': {'_static/momentum_logo.png'}},
 ):
     """Enforce the site-wide figure labelling policy.
 
@@ -71,10 +71,6 @@ def validate_figure_labelling(
     for decorative images that should not be numbered. Keys are Sphinx docnames
     and values are image URIs as they appear in the doctree.
     """
-    if unnumbered_images_by_doc is None:
-        unnumbered_images_by_doc = {
-            'index': {'_static/momentum_logo.png'},
-        }
 
     def node_location(node):
         location = getattr(node, 'source', '<unknown source>')

--- a/source/conf.py
+++ b/source/conf.py
@@ -33,7 +33,14 @@ extensions = [
 ]
 
 templates_path = ['_templates']
-exclude_patterns = []
+# These files are included by practical_exercises.rst. If Sphinx also
+# discovers them as standalone documents, labels inside the fragments are
+# registered twice and produce duplicate-label warnings.
+exclude_patterns = [
+    'lfric_infrastructure/practical_command_line.rst',
+    'lfric_infrastructure/practical_standard_suite.rst',
+    'lfric_infrastructure/practical_stem_test.rst',
+]
 
 # -- Figure numbering --------------------------------------------------------
 numfig = True

--- a/source/conf.py
+++ b/source/conf.py
@@ -35,6 +35,9 @@ extensions = [
 templates_path = ['_templates']
 exclude_patterns = []
 
+# -- Figure numbering --------------------------------------------------------
+numfig = True
+
 # -- layout -----------------------------------------------------------------
 # https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,5 +1,7 @@
 import sys
 import os
+from collections.abc import Mapping
+from types import MappingProxyType
 
 from docutils import nodes
 from sphinx.application import Sphinx
@@ -54,9 +56,9 @@ def validate_figure_labelling(
     app: Sphinx,
     doctree: nodes.document,
     *,
-    unnumbered_images_by_doc: dict[str, set[str]] = {
-        'index': {'_static/momentum_logo.png'},
-    },
+    unnumbered_images_by_doc: Mapping[str, frozenset[str]] = MappingProxyType({
+        'index': frozenset({'_static/momentum_logo.png'}),
+    }),
 ) -> None:
     """Enforce the site-wide figure labelling policy.
 
@@ -72,9 +74,9 @@ def validate_figure_labelling(
     * a ``figure`` directive has no alt text; or
     * an unallowlisted ``image`` directive remains outside a figure.
 
-    ``unnumbered_images_by_doc`` intentionally defaults to a narrow allowlist
-    for decorative images that should not be numbered. Keys are Sphinx docnames
-    and values are normalized image URIs.
+    ``unnumbered_images_by_doc`` intentionally defaults to an immutable narrow
+    allowlist for decorative images that should not be numbered. Keys are Sphinx
+    docnames and values are normalized image URIs.
     """
 
     def node_location(node: nodes.Node) -> str:
@@ -112,7 +114,7 @@ def validate_figure_labelling(
         if isinstance(image.parent, nodes.figure):
             continue
         uri = image_uri(image)
-        allowed = unnumbered_images_by_doc.get(app.env.docname, set())
+        allowed = unnumbered_images_by_doc.get(app.env.docname, frozenset())
         if uri not in allowed:
             errors.append(
                 f"{node_location(image)}: image directive for '{uri}' must "

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,6 +1,9 @@
 import sys
 import os
 
+from docutils import nodes
+from sphinx.errors import ExtensionError
+
 sys.path.append(os.path.abspath('../lib/'))
 
 # Configuration file for the Sphinx documentation builder.
@@ -44,6 +47,61 @@ exclude_patterns = [
 
 # -- Figure numbering --------------------------------------------------------
 numfig = True
+
+_UNNUMBERED_IMAGES = {
+    'index': {'_static/momentum_logo.png'},
+}
+
+
+def _node_location(node):
+    location = getattr(node, 'source', '<unknown source>')
+    line = getattr(node, 'line', None)
+    return f'{location}:{line}' if line else location
+
+
+def _image_uri(image):
+    return image.get('uri', '').lstrip('/')
+
+
+def _validate_figure_labelling(app, doctree):
+    errors = []
+
+    for figure in doctree.findall(nodes.figure):
+        image = next(figure.findall(nodes.image), None)
+        uri = _image_uri(image) if image else '<missing image>'
+        names = figure.get('names', [])
+        if not any(name.startswith('fig-') for name in names):
+            errors.append(
+                f"{_node_location(figure)}: figure for '{uri}' is missing "
+                "a '.. _fig-...:' label."
+            )
+        if not any(isinstance(child, nodes.caption) and child.astext().strip()
+                   for child in figure.children):
+            errors.append(
+                f"{_node_location(figure)}: figure for '{uri}' is missing "
+                'a caption.'
+            )
+
+    for image in doctree.findall(nodes.image):
+        if isinstance(image.parent, nodes.figure):
+            continue
+        uri = _image_uri(image)
+        allowed = _UNNUMBERED_IMAGES.get(app.env.docname, set())
+        if uri not in allowed:
+            errors.append(
+                f"{_node_location(image)}: image directive for '{uri}' must "
+                'be converted to a labelled figure or explicitly allowlisted.'
+            )
+
+    if errors:
+        message = 'Figure labelling validation failed:\n'
+        message += '\n'.join(f'- {error}' for error in errors)
+        raise ExtensionError(message)
+
+
+def setup(app):
+    app.connect('doctree-read', _validate_figure_labelling)
+    return {'version': '1.0', 'parallel_read_safe': True}
 
 # -- layout -----------------------------------------------------------------
 # https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#

--- a/source/conf.py
+++ b/source/conf.py
@@ -48,48 +48,68 @@ exclude_patterns = [
 # -- Figure numbering --------------------------------------------------------
 numfig = True
 
-_UNNUMBERED_IMAGES = {
-    'index': {'_static/momentum_logo.png'},
-}
+def validate_figure_labelling(
+    app,
+    doctree,
+    *,
+    unnumbered_images_by_doc=None,
+):
+    """Enforce the site-wide figure labelling policy.
 
+    Issue #122 requires all content figures to have consistent numbering,
+    captions, and cross-reference targets. Sphinx can number figures once
+    ``numfig`` is enabled, but only if content uses ``figure`` directives with
+    explicit labels and captions.
 
-def _node_location(node):
-    location = getattr(node, 'source', '<unknown source>')
-    line = getattr(node, 'line', None)
-    return f'{location}:{line}' if line else location
+    This hook runs while Sphinx reads each doctree and fails the build when:
 
+    * a ``figure`` directive has no ``fig-*`` label;
+    * a ``figure`` directive has no caption; or
+    * an unallowlisted ``image`` directive remains outside a figure.
 
-def _image_uri(image):
-    return image.get('uri', '').lstrip('/')
+    ``unnumbered_images_by_doc`` intentionally defaults to a narrow allowlist
+    for decorative images that should not be numbered. Keys are Sphinx docnames
+    and values are image URIs as they appear in the doctree.
+    """
+    if unnumbered_images_by_doc is None:
+        unnumbered_images_by_doc = {
+            'index': {'_static/momentum_logo.png'},
+        }
 
+    def node_location(node):
+        location = getattr(node, 'source', '<unknown source>')
+        line = getattr(node, 'line', None)
+        return f'{location}:{line}' if line else location
 
-def _validate_figure_labelling(app, doctree):
+    def image_uri(image):
+        return image.get('uri', '').lstrip('/')
+
     errors = []
 
     for figure in doctree.findall(nodes.figure):
         image = next(figure.findall(nodes.image), None)
-        uri = _image_uri(image) if image else '<missing image>'
+        uri = image_uri(image) if image else '<missing image>'
         names = figure.get('names', [])
         if not any(name.startswith('fig-') for name in names):
             errors.append(
-                f"{_node_location(figure)}: figure for '{uri}' is missing "
+                f"{node_location(figure)}: figure for '{uri}' is missing "
                 "a '.. _fig-...:' label."
             )
         if not any(isinstance(child, nodes.caption) and child.astext().strip()
                    for child in figure.children):
             errors.append(
-                f"{_node_location(figure)}: figure for '{uri}' is missing "
+                f"{node_location(figure)}: figure for '{uri}' is missing "
                 'a caption.'
             )
 
     for image in doctree.findall(nodes.image):
         if isinstance(image.parent, nodes.figure):
             continue
-        uri = _image_uri(image)
-        allowed = _UNNUMBERED_IMAGES.get(app.env.docname, set())
+        uri = image_uri(image)
+        allowed = unnumbered_images_by_doc.get(app.env.docname, set())
         if uri not in allowed:
             errors.append(
-                f"{_node_location(image)}: image directive for '{uri}' must "
+                f"{node_location(image)}: image directive for '{uri}' must "
                 'be converted to a labelled figure or explicitly allowlisted.'
             )
 
@@ -100,7 +120,8 @@ def _validate_figure_labelling(app, doctree):
 
 
 def setup(app):
-    app.connect('doctree-read', _validate_figure_labelling)
+    """Register local Sphinx validation hooks."""
+    app.connect('doctree-read', validate_figure_labelling)
     return {'version': '1.0', 'parallel_read_safe': True}
 
 # -- layout -----------------------------------------------------------------

--- a/source/introduction/components.rst
+++ b/source/introduction/components.rst
@@ -3,6 +3,8 @@ Components, Science Configurations, and Systems
 
 Components of the `Momentum  <https://www.metoffice.gov.uk/research/approach/modelling-systems/momentum>`_ Framework, like the atmospheric model LFRic Atmosphere, are combined to prediction and projection systems, like the ones mentioned in the graphic in the seamless modelling section. Science Configurations are rigorously tested  and define the exact setup for the individual model components. These configurations are distinguished between regional and global configurations. Additionally, there are coupled Science Configurations which detail multi-model setups, e.g. an atmosphere - ocean model.
 
+.. _fig-intro-components:
+
 .. figure:: /_static/1/intro_components.png
    :width: 650px
    :alt: Components of prediction and projection systems

--- a/source/introduction/history_context.rst
+++ b/source/introduction/history_context.rst
@@ -5,6 +5,8 @@ LFRic Atmosphere has been `developed <https://www.metoffice.gov.uk/research/news
 
 LFRic Atmosphere uses the same terrain-following vertical coordinates as the Unified Model but has a cubed sphere mesh, a new mixed finite-element dynamical core, GungHo, and a new coding infrastructure. The cubed sphere mesh avoids the pole singularity problem of longitude–latitude grids which prohibits scaling the Unified Model to km-scale global grids. The coding infrastructure separates details of code parallelisation from the mathematical formulation of the physical representation of the atmosphere. This separation of concerns allows for easier optimisation of the same model code for different compute platforms.
 
+.. _fig-intro-mesh-vertical:
+
 .. figure:: /_static/1/lfric_mesh_and_vertical_grid.png
    :width: 650px
    :alt: lfric mesh and vertical grid

--- a/source/introduction/seamless_modelling.rst
+++ b/source/introduction/seamless_modelling.rst
@@ -5,6 +5,8 @@ Seamless Modelling
 
 Since the 1990's the Met Office strategy has been to develop a single model family used for prediction across a range of timescales. This means the same dynamical core and, where possible, the same parameterization schemes are used across a broad range of spatial and temporal scales. The image below shows Met Office prediction and projection systems configured for applications on different scales, ranging from a few days to hundreds of years.
 
+.. _fig-intro-seamless:
+
 .. figure:: /_static/1/intro_seamless.png
    :width: 650px
 

--- a/source/introduction/seamless_modelling.rst
+++ b/source/introduction/seamless_modelling.rst
@@ -9,6 +9,7 @@ Since the 1990's the Met Office strategy has been to develop a single model fami
 
 .. figure:: /_static/1/intro_seamless.png
    :width: 650px
+   :alt: Met Office prediction and projection systems across spatial and temporal scales
 
    Spatial and temporal scales of Met Office prediction and projection systems.
 

--- a/source/lfric_infrastructure/practical_command_line.rst
+++ b/source/lfric_infrastructure/practical_command_line.rst
@@ -10,6 +10,7 @@
 .. _Git on MONSooN: https://code.metoffice.gov.uk/doc/monsoon3/github.html#github
 
 .. _practical_3.1:
+
 Practical 1: Run the model from command line
 --------------------------------------------
 

--- a/source/lfric_infrastructure/practical_standard_suite.rst
+++ b/source/lfric_infrastructure/practical_standard_suite.rst
@@ -67,6 +67,8 @@ Step 2: Explore the workflow
       Can you match each task description above with a folder in the
       ``app`` directory?
 
+   .. _fig-infra-standard-suite:
+
    .. graphviz::
       :caption: Graph of the LFRic Apps Standard Suite.
 

--- a/source/lfric_infrastructure/psykal_infrastructure.rst
+++ b/source/lfric_infrastructure/psykal_infrastructure.rst
@@ -29,6 +29,8 @@ PSyKAl (
 * Parallelism is implemented in the :external+psyclone:ref:`psy-layer` which
   is auto generated with a tool called :external+psyclone:doc:`PSyclone <index>`
 
+.. _fig-infra-psykal:
+
 .. figure:: /_static/psykal.png
    :width: 650px
 

--- a/source/lfric_infrastructure/psykal_infrastructure.rst
+++ b/source/lfric_infrastructure/psykal_infrastructure.rst
@@ -33,5 +33,6 @@ PSyKAl (
 
 .. figure:: /_static/psykal.png
    :width: 650px
+   :alt: PSyKAl architecture separating natural science code from computational science code
 
    Separation of Natural and Computational Science in the PSyKAl architecture.

--- a/source/lfric_infrastructure/working_practices.rst
+++ b/source/lfric_infrastructure/working_practices.rst
@@ -14,7 +14,6 @@ Topics include:
 * :external+simulation_systems:ref:`development_index`
 * :external+simulation_systems:ref:`multirepo`
 * :external+simulation_systems:ref:`testing`
-* :external+simulation_systems:ref:`multirepo`
 * The :external+simulation_systems:ref:`review_process`
 
 .. _fig-infra-working-practices:

--- a/source/lfric_infrastructure/working_practices.rst
+++ b/source/lfric_infrastructure/working_practices.rst
@@ -21,6 +21,7 @@ Topics include:
 
 .. figure:: /_static/working_practices.jpg
    :width: 650px
+   :alt: Simulation Systems Working Practices web page
 
    Simulation Systems Working Practices.
 

--- a/source/lfric_infrastructure/working_practices.rst
+++ b/source/lfric_infrastructure/working_practices.rst
@@ -17,6 +17,8 @@ Topics include:
 * :external+simulation_systems:ref:`multirepo`
 * The :external+simulation_systems:ref:`review_process`
 
+.. _fig-infra-working-practices:
+
 .. figure:: /_static/working_practices.jpg
    :width: 650px
 

--- a/source/lfric_infrastructure/working_practices.rst
+++ b/source/lfric_infrastructure/working_practices.rst
@@ -21,7 +21,7 @@ Topics include:
 
 .. figure:: /_static/working_practices.jpg
    :width: 650px
-   :alt: Simulation Systems Working Practices web page
+   :alt: Simulation Systems Working Practices
 
    Simulation Systems Working Practices.
 

--- a/source/mesh_overview/structured/structured_overview/structured_overview.rst
+++ b/source/mesh_overview/structured/structured_overview/structured_overview.rst
@@ -9,11 +9,13 @@ Consider a 2-dimensional array representing geographical data in a structured gr
 In this context, the shape of the data in the array corresponds directly to the shape of the physical space we are modelling—in this case, Earth's surface.
 Each element in the array represents a distinct location in the physical world.
 
-The figure below visualises this concept:
+:numref:`fig-mesh-structured-world` visualises this concept:
 
 * In the 2D array below, the rows represent the West to East direction, and the columns represent the South to North direction.
 * Neighbouring data points in the array are also neighbours in the physical space. This spatial organisation simplifies how we relate computational data to real-world positions.
 * The alignment between data points and physical space provides a clear, intuitive structure that makes it easy to manipulate and analyse the data.
+
+.. _fig-mesh-structured-world:
 
 .. figure:: /_static/structured_world.svg
    :width: 650px
@@ -43,7 +45,9 @@ While structured grids work well in many cases, they do have some limitations:
 1. Singularities at the poles:
 
    One of the most well-known issues with structured grids, particularly in Earth-system modelling, is the singularity at the poles. At the North and South Poles, grid cells become excessively compressed, leading to inaccuracies and computational challenges. This is a direct result of representing a spherical Earth with a flat grid, which leads to distortion near the poles.
-   The figure below demonstrates singularities at the poles.
+   :numref:`fig-mesh-singularities` demonstrates singularities at the poles.
+
+.. _fig-mesh-singularities:
 
 .. figure:: /_static/singularities.png
    :width: 300px

--- a/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
+++ b/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
@@ -125,6 +125,7 @@ LFRic Atmosphere uses a cubed sphere mesh. Meshes are named after the number of 
 .. _fig-mesh-cubed-sphere-animation:
 
 .. figure:: /_static/mesh_animation.gif
+   :alt: C16 cubed sphere mesh projected onto a sphere
 
    Visualisation of a C16 mesh and how the mesh on a cube is projected to a sphere.
 

--- a/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
+++ b/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
@@ -25,7 +25,9 @@ Thanks to its use of an unstructured mesh, LFRic atmosphere offers greater flexi
 * **Scalability**: Unstructured meshes enable higher-order methods, making it easier to scale models for larger, more detailed simulations.
 
 To fully benefit from these features, working with unstructured data and understanding the UGRID format, which efficiently handles this type of data, is essential.
-The figure below shows examples of unstructured meshes.
+:numref:`fig-mesh-unstructured-examples` shows examples of unstructured meshes.
+
+.. _fig-mesh-unstructured-examples:
 
 .. figure:: /_static/unstructured_examples.png
    :width: 650px
@@ -36,6 +38,8 @@ The figure below shows examples of unstructured meshes.
 
 UGRID description of unstructured data
 --------------------------------------
+.. _fig-mesh-ugrid-elements:
+
 .. figure:: /_static/mesh1.png
    :align: right
    :width: 160px
@@ -60,6 +64,8 @@ In the unstructured mesh approach, cells are described using a variety of elemen
 
 One key distinction is that in the mesh approach, each element is assigned its own description. In contrast, in structured grids, a single bound is used to describe the entire cell, which can lead to greater efficiency when describing certain elements (e.g., a line). However, this efficiency comes at the cost of flexibility, as the structured approach is less adaptable to complex geometries.
 
+.. _fig-mesh-structured-vs-unstructured:
+
 .. figure:: /_static/mesh2.png
    :width: 650px
    :alt: structured vs unstructured mesh elements
@@ -72,6 +78,8 @@ Managing unstructured data
 When working with unstructured data, the amount of data to handle increases significantly. For example, imagine 5 million cells are arranged on a flat layer.
 In the case of the Unified Model (UM) on the left, 13,400 data points (points and bounds) are needed to describe the entire space. However, in the unstructured case, because everything is described individually, around 40 million data points are required to represent the same space.
 
+
+.. _fig-mesh-data-volume:
 
 .. figure:: /_static/mesh3.png
    :width: 650px
@@ -91,7 +99,9 @@ For example, fluxes could be represented on all six faces of a cube—four horiz
 Complexity of operations
 ++++++++++++++++++++++++
 Another consideration when working with unstructured data is the increased complexity of operations. In a structured grid, extracting data from a specific region is relatively simple.
-For example, in the below figure, to extract data from rows 3 to 4 and columns 3 to 5, the array can easily be sliced to extract that data.
+For example, in :numref:`fig-mesh-data-extraction`, to extract data from rows 3 to 4 and columns 3 to 5, the array can easily be sliced to extract that data.
+
+.. _fig-mesh-data-extraction:
 
 .. figure:: /_static/data-extraction.png
    :width: 650px
@@ -163,6 +173,8 @@ Iris is a Python-based ecosystem and package used for the manipulation of LFRic 
 It is open-source and has been included in other tools, such as ESMValTool and MetPlus, which are based on it.
 Iris offers a unified view of data as cubes and supports metadata-aware processing. It provides analysis capabilities in mathematics, statistics, large data handling, and regridding. For visualisation, Iris relies on Matplotlib and Cartopy.
 
+.. _fig-mesh-unstructured-tools:
+
 .. figure:: /_static/unstructured_tools.png
    :width: 650px
    :alt: unstructured data tools
@@ -198,6 +210,8 @@ Key features of regridding include:
 - the ability to preserve metadata, and
 - efficient handling of masked data.
 
+
+.. _fig-mesh-regrid:
 
 .. figure:: /_static/regrid.png
    :width: 400px

--- a/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
+++ b/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
@@ -120,7 +120,9 @@ When dealing with Limited Area Models (LAMs), we focus on a smaller section of t
 Cubed sphere mesh
 -----------------
 
-LFRic Atmosphere uses a cubed sphere mesh. Meshes are named after the number of cells along one edge of the cube. The visualisation shows a C16 mesh, which represents the Earth's surface by 6 x 16 x 16 = 1536 cells ("squares") in each horizontal layer. Most cell corners have four neighbour cells but at the corners of the cube only three cells meet.
+LFRic Atmosphere uses a cubed sphere mesh. Meshes are named after the number of cells along one edge of the cube. :numref:`fig-mesh-cubed-sphere-animation` shows a C16 mesh, which represents the Earth's surface by 6 x 16 x 16 = 1536 cells ("squares") in each horizontal layer. Most cell corners have four neighbour cells but at the corners of the cube only three cells meet.
+
+.. _fig-mesh-cubed-sphere-animation:
 
 .. figure:: /_static/mesh_animation.gif
 

--- a/source/modelling/gc_practical_exercises/plotting/plotting.rst
+++ b/source/modelling/gc_practical_exercises/plotting/plotting.rst
@@ -15,5 +15,6 @@ Plotting your data
 
 .. figure:: /_static/plotting.png
    :width: 650px
+   :alt: Example plotted diagnostic output from a GC practical exercise
 
    Plotting output from a GC practical exercise.

--- a/source/modelling/gc_practical_exercises/plotting/plotting.rst
+++ b/source/modelling/gc_practical_exercises/plotting/plotting.rst
@@ -11,5 +11,9 @@ Plotting your data
 * Run the script
 
 
-.. image:: /_static/plotting.png
+.. _fig-model-plotting:
+
+.. figure:: /_static/plotting.png
    :width: 650px
+
+   Plotting output from a GC practical exercise.

--- a/source/modelling/introduction/core_models/core_models.rst
+++ b/source/modelling/introduction/core_models/core_models.rst
@@ -26,6 +26,8 @@ For example, in the Global Coupled (GC) approach, certain components are strongl
 
 The diagram below illustrates coupling components in the GC approach.
 
+.. _fig-model-gc-components:
+
 .. figure:: /_static/components.png
    :width: 650px
    :alt: components in a GC-LFRic configuration

--- a/source/modelling/introduction/index.rst
+++ b/source/modelling/introduction/index.rst
@@ -18,5 +18,9 @@ Science configurations are constructed from component models, each of which repr
 
 This chapter first introduces the component models used within the Momentum framework and explains how they are coupled. It then describes the concept of science configurations, their testing and release process, and their role in supporting seamless modelling across research and operational applications.
 
-.. image:: /_static/seamless_modelling.png
+.. _fig-model-seamless:
+
+.. figure:: /_static/seamless_modelling.png
    :width: 650px
+
+   Seamless modelling across spatial and temporal scales.

--- a/source/modelling/introduction/index.rst
+++ b/source/modelling/introduction/index.rst
@@ -22,5 +22,6 @@ This chapter first introduces the component models used within the Momentum fram
 
 .. figure:: /_static/seamless_modelling.png
    :width: 650px
+   :alt: Weather and climate modelling applications across spatial and temporal scales
 
    Seamless modelling across spatial and temporal scales.

--- a/source/modelling/med/model_development.rst
+++ b/source/modelling/med/model_development.rst
@@ -16,8 +16,12 @@ The evaluation teams (regional known as RMED and global, GMED) have strong links
   
    * If interested, find the PEG or CoG lead on the GMED or RMED Met Office Science Repository Service (MOSRS) pages and contact them, or you can contact Momentum_Partnership@metoffice.gov.uk.
 
-.. image:: /_static/seamless_dev_cycle.png
+.. _fig-model-dev-cycle:
+
+.. figure:: /_static/seamless_dev_cycle.png
    :width: 650px
+
+   The seamless development cycle for Global Coupled configurations.
 
 In July 2022, the final UM-based GC configuration was released, 'GC5', before the implementation of the LFRic atmospheric model into GC configurations. LFRic atmosphere is the next-generation atmospheric model being developed by the Momentum framework, which is designed to be more modular and flexible than its predecessor.
 

--- a/source/modelling/med/model_development.rst
+++ b/source/modelling/med/model_development.rst
@@ -20,6 +20,7 @@ The evaluation teams (regional known as RMED and global, GMED) have strong links
 
 .. figure:: /_static/seamless_dev_cycle.png
    :width: 650px
+   :alt: Development cycle for Global Coupled science configurations
 
    The seamless development cycle for Global Coupled configurations.
 

--- a/source/modelling/med/model_evaluation.rst
+++ b/source/modelling/med/model_evaluation.rst
@@ -13,8 +13,12 @@ The Met Office maintains routine tools for validation of GC configurations:
 * `ESMValTool <https://esmvaltool.org/>`_
 * `MetPlus <https://dtcenter.org/community-code/metplus>`_
 
-.. image:: /_static/autoassess.png
+.. _fig-model-autoassess:
+
+.. figure:: /_static/autoassess.png
    :width: 700px
+
+   AutoAssess evaluation tools for model assessment.
 
 Regional evaluation tools
 -------------------------

--- a/source/modelling/med/model_evaluation.rst
+++ b/source/modelling/med/model_evaluation.rst
@@ -17,6 +17,7 @@ The Met Office maintains routine tools for validation of GC configurations:
 
 .. figure:: /_static/autoassess.png
    :width: 700px
+   :alt: AutoAssess workflow for evaluating science configurations
 
    AutoAssess evaluation tools for model assessment.
 

--- a/source/modelling/tools/cylc/cylc.rst
+++ b/source/modelling/tools/cylc/cylc.rst
@@ -9,6 +9,7 @@ Cylc - workflow engine
 
 .. figure:: /_static/cylc.gif
    :width: 700px
+   :alt: Cylc workflow graph visualisation
 
    Cylc workflow visualisation.
 

--- a/source/modelling/tools/cylc/cylc.rst
+++ b/source/modelling/tools/cylc/cylc.rst
@@ -5,8 +5,12 @@ Cylc - workflow engine
 * Cylc workflows can be organized running tasks at specific clock cycles.
 * Cylc workflows represent the highest-level programming layer for organising the execution of our models, pre- and postprocessors.
 
-.. image:: /_static/cylc.gif
+.. _fig-model-cylc:
+
+.. figure:: /_static/cylc.gif
    :width: 700px
+
+   Cylc workflow visualisation.
 
 .. note::
    * Comprehensive guides and training for cylc can be found here: https://cylc.github.io/cylc-doc.

--- a/source/modelling/tools/rose/rose.rst
+++ b/source/modelling/tools/rose/rose.rst
@@ -2,9 +2,13 @@
 Rose - managing model configurations
 ************************************
 
-.. image:: /_static/rose.png
+.. _fig-model-rose:
+
+.. figure:: /_static/rose.png
    :align: right
    :width: 200px
+
+   Rose configuration management tool.
 
 * Rose is a tool for writing, editing, updating, and running configurations of applications
 * Rose allows top-level configuration of applications for workflows used for LFRic model experiments

--- a/source/modelling/tools/rose/rose.rst
+++ b/source/modelling/tools/rose/rose.rst
@@ -7,6 +7,7 @@ Rose - managing model configurations
 .. figure:: /_static/rose.png
    :align: right
    :width: 200px
+   :alt: Rose configuration management tool logo
 
    Rose configuration management tool.
 


### PR DESCRIPTION
## Summary

Resolves #122.

`conf.py` enforces a site-wide figure policy: every figure must have a `fig-*` label, a caption, and alt text — or be explicitly allowlisted as a decorative image. The build fails if any figure violates these rules.

All other changes in this PR exist to satisfy that requirement:

- Enable `numfig = True` in `conf.py` for automatic figure numbering
- Add RST labels (`.. _fig-xxx:`) and captions to all 24 content figures across the site
- Convert 6 content `.. image::` directives to `.. figure::` directives with captions
- Add descriptive `:alt:` text to every numbered content figure
- Update text references to use `:numref:` cross-references where figures were mentioned informally

The root Momentum logo (`momentum_logo.png`) remains an explicitly allowlisted decorative image and is not numbered.