### PR TITLE
Add repository AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,8 @@ It is primarily a Sphinx documentation project with a bundled copy of the
 - Prefer small, reviewable documentation edits over broad rewrites.
 - Match existing terminology: "Momentum", "LFRic Atmosphere", "science
   configurations", and "working practices" all have established meanings in the
-  training content.
+  training content. Use the definitions in `source/glossary.rst` when you need
+  explicit project context.
 - Do not change dependency-management conventions casually. If new dependencies
   are necessary, update `pyproject.toml` and keep the README setup instructions
   consistent with that change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,148 @@
+# AGENTS.md
+
+## Purpose
+
+This repository publishes the LFRic Atmosphere self-learning training site.
+It is primarily a Sphinx documentation project with a bundled copy of the
+`iris-mesh-tutorial` notebooks for learner delivery.
+
+## Repository map
+
+- `README.md`: contributor setup, dependency policy, and the canonical local
+  build instructions.
+- `pyproject.toml`: reference dependency manifest for the `uv` workflow and CI.
+  This repository is not currently installable as a Python library. Do not add
+  `requirements.txt` files or commit lockfiles here.
+- `pixi.toml`: completely optional conda-first alternative environment
+  definition. Keep it aligned with the docs and notebook stack when relevant,
+  but treat `uv` as the reference workflow unless the user explicitly asks to
+  prefer Pixi.
+- `Makefile`: thin wrapper around `sphinx-build -M ...`.
+- `source/`: Sphinx documentation sources.
+- `source/index.rst`: root toctree for the published training site.
+- `source/conf.py`: Sphinx extensions, theme settings, GitHub edit links, and
+  custom static assets.
+- `source/_static/`: images, CSS, JS, and video referenced by the docs.
+- `source/_templates/`: custom sidebar/footer templates.
+- `notebooks/iris-mesh-tutorial/`: local training-delivery copy of the upstream
+  `scitools-classroom/iris-mesh-tutorial` project.
+- `.github/workflows/deploy_pages.yml`: CI path used for the published site.
+
+## Environment and setup
+
+- Supported Python is `>=3.11,<3.13`; GitHub Pages CI currently builds with
+  Python `3.11`.
+- Preferred docs setup:
+
+  ```bash
+  uv sync --python 3.11
+  source .venv/bin/activate
+  ```
+
+- Optional Pixi setup:
+
+  ```bash
+  pixi install
+  pixi run html
+  ```
+
+- Optional extras are defined in `pyproject.toml`:
+  - `dev` for contributor tooling such as `pre-commit`
+  - `notebooks` for local notebook work
+  - `mesh_tutorials` for the bundled mesh tutorial workflow
+- `pixi.toml` intentionally flattens these into one optional environment
+  instead of mirroring the `pyproject.toml` extras one-for-one. Keep the
+  matching version constraints aligned across the two files when relevant.
+- Some matching constraints are written differently because the tools use
+  different version-spec syntaxes. In particular, Pixi / Conda-style entries
+  such as `0.5.3.*` and `1.14.4.*` are the tooling-compatible form of the same
+  effective pin represented in `pyproject.toml` as `==0.5.3` and `==1.14.4`;
+  treat that as a syntax difference, not a real environment difference.
+- Although `pyproject.toml` contains `[project]` metadata, the repository is
+  not currently an installable Python package. Do not recommend
+  `pip install .` or `pip install -e .` as the normal setup route.
+- The mesh tutorial regridding practicals need `esmpy`. The repository
+  currently references it in `notebooks/README.md`, the bundled mesh tutorial
+  setup instructions, `source/mesh_overview/exercises/practical_exercises.rst`,
+  and the Pixi `mesh-import-check` task. GitHub Pages CI does not install or
+  use `esmpy`; the deploy workflow still builds with `uv sync` and
+  `uv run make clean html`.
+- The regridding package name differs by ecosystem: use `esmf-regrid` for the
+  PyPI / `pyproject.toml` dependency and `iris-esmf-regrid` for the Conda /
+  `pixi.toml` dependency.
+- `sphinxcontrib-quizdown` is not available on conda-forge. Keep it under
+  Pixi's `[pypi-dependencies]` as a Git-sourced package rather than moving it
+  into `[dependencies]`.
+- Dependency policy in `README.md` is explicit: `uv` remains the reference
+  workflow, while `pixi.toml` is an optional alternative.
+
+## Editing guidance
+
+- Keep changes learner-focused and introductory. The audience is new to LFRic
+  Atmosphere and related workflows.
+- Most content is authored in reStructuredText. Preserve heading hierarchy,
+  directive indentation, and existing toctree structure.
+- When adding or moving pages, update the relevant `index.rst` or other
+  containing toctree so the page is reachable in the built site.
+- Put new images or downloadable static assets in `source/_static/` and
+  reference them from the relevant `.rst` page.
+- If you change navigation or page chrome, inspect the full set of related
+  files together:
+  - `source/conf.py`
+  - `source/_templates/globaltoc.html`
+  - `source/_templates/show-accessibility.html`
+  - `source/_static/nav-collapse.css`
+  - `source/_static/nav-collapse.js`
+- Notebook content under `notebooks/iris-mesh-tutorial/notebooks/` is stored as
+  plain `.ipynb` files, not as paired Jupytext sources.
+- Keep notebook diffs tight. Avoid unnecessary execution-count churn or large
+  output blobs unless the output is intentionally part of the training
+  material.
+- Helper code for the mesh tutorial lives under
+  `notebooks/iris-mesh-tutorial/notebooks/support/`.
+- The mesh tutorial copy is downstream training material. Keep LFRic-specific
+  adaptations in this repository, but treat generic improvements as upstream
+  candidates for `scitools-classroom/iris-mesh-tutorial`.
+
+## Validation
+
+- Standard local validation for doc changes:
+
+  ```bash
+  uv run make clean html
+  ```
+
+- Useful extra checks when touching RST structure or links:
+
+  ```bash
+  uv run sphinx-lint source
+  uv run make linkcheck
+  ```
+
+- The deployed site is built from `main` by GitHub Actions using:
+
+  ```bash
+  uv sync
+  uv run make clean html
+  ```
+
+- For notebook changes, there is no dedicated notebook CI in this repository.
+  Smoke-test the changed notebook or helper code locally where practical.
+- For the mesh tutorial, launch Jupyter from
+  `notebooks/iris-mesh-tutorial/notebooks/` so local paths and imports match
+  the training instructions.
+
+## Working norms for agents
+
+- Prefer small, reviewable documentation edits over broad rewrites.
+- Match existing terminology: "Momentum", "LFRic Atmosphere", "science
+  configurations", and "working practices" all have established meanings in the
+  training content.
+- Do not change dependency-management conventions casually. If new dependencies
+  are necessary, update `pyproject.toml` and keep the README setup instructions
+  consistent with that change. If the change also affects the optional Pixi
+  environment, update `pixi.toml` too.
+- Do not add packaging boilerplate or treat this repository as a distributable
+  Python library unless the user explicitly asks for that change.
+- Do not commit generated `build/` output, virtual environments, or notebook
+  checkpoint files; those are already ignored.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,10 @@ It is primarily a Sphinx documentation project with a bundled copy of the
 
 - `README.md`: contributor setup, dependency policy, and the canonical local
   build instructions.
-- `pyproject.toml`: dependency manifest for the `uv` workflow, the `pip`
-  workflow, and CI. The project metadata is used to install dependencies, but
-  this repository does not currently expose importable Python package modules.
-  Do not add `requirements.txt` files here.
+- `pyproject.toml`: dependency manifest for the `uv` workflow and CI. The
+  project metadata is used to install dependencies, but this repository does
+  not currently expose importable Python package modules. Do not add
+  `requirements.txt` files here.
 - `Makefile`: thin wrapper around `sphinx-build -M ...`.
 - `source/`: Sphinx documentation sources.
 - `source/index.rst`: root toctree for the published training site.
@@ -29,40 +29,34 @@ It is primarily a Sphinx documentation project with a bundled copy of the
 
 - Supported Python is `>=3.11,<3.13`; GitHub Pages CI currently builds with
   Python `3.11`.
-- Preferred docs setup:
+- Agents should use `uv` for setup and task execution. Preferred docs setup:
 
   ```bash
   uv sync --python 3.11
-  source .venv/bin/activate
-  ```
-
-- Alternative `venv`/`conda` plus `pip` setup:
-
-  ```bash
-  /path/to/python3.11+ -m venv .venv
-  source .venv/bin/activate
-  pip install .
   ```
 
 - Optional extras are defined in `pyproject.toml`:
   - `dev` for contributor tooling such as `pre-commit`
   - `notebooks` for local notebook work
   - `mesh_tutorials` for the bundled mesh tutorial workflow
-- Use `pip install ".[notebooks,mesh_tutorials,dev]"` to install all optional
-  dependency groups in a `venv` or conda environment. For contributor work in
-  that route, `pip install -e ".[notebooks,mesh_tutorials,dev]"` is documented
-  in `README.md`.
+- Install optional dependency groups with `uv` as needed:
+  - `uv sync --extra dev`
+  - `uv sync --extra notebooks`
+  - `uv sync --extra mesh_tutorials`
+  - `uv sync --all-extras`
 - The `[tool.uv] package = false` setting means `uv sync` installs the
-  dependency environment without installing the project itself. Keep this
-  distinction in mind when comparing `uv` and `pip` setup routes.
+  dependency environment without installing the project itself.
 - The mesh tutorial regridding practicals need `esmpy`. The repository
   currently references it in `notebooks/README.md`, the bundled mesh tutorial
   setup instructions, `source/mesh_overview/exercises/practical_exercises.rst`,
-  and related notebooks. GitHub Pages CI does not install or use `esmpy`; the
-  deploy workflow still builds with `uv sync` and `uv run make clean html`.
+  and related notebooks. Some learner-facing notebook instructions use conda to
+  provide `esmpy`, but agents should keep repository setup and validation on
+  the `uv` workflow unless explicitly asked to test that notebook environment.
+  GitHub Pages CI does not install or use `esmpy`; the deploy workflow still
+  builds with `uv sync` and `uv run make clean html`.
 - Use the PyPI package name `esmf-regrid` in `pyproject.toml`.
 - Dependency policy in `README.md` is explicit: build environments from
-  `pyproject.toml` only, using either `uv` or `venv`/`conda` plus `pip`.
+  `pyproject.toml` only. For agents, use `uv`.
 
 ## Editing guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,10 @@ It is primarily a Sphinx documentation project with a bundled copy of the
 
 - `README.md`: contributor setup, dependency policy, and the canonical local
   build instructions.
-- `pyproject.toml`: reference dependency manifest for the `uv` workflow and CI.
-  This repository is not currently installable as a Python library. Do not add
-  `requirements.txt` files or commit lockfiles here.
-- `pixi.toml`: completely optional conda-first alternative environment
-  definition. Keep it aligned with the docs and notebook stack when relevant,
-  but treat `uv` as the reference workflow unless the user explicitly asks to
-  prefer Pixi.
+- `pyproject.toml`: dependency manifest for the `uv` workflow, the `pip`
+  workflow, and CI. The project metadata is used to install dependencies, but
+  this repository does not currently expose importable Python package modules.
+  Do not add `requirements.txt` files here.
 - `Makefile`: thin wrapper around `sphinx-build -M ...`.
 - `source/`: Sphinx documentation sources.
 - `source/index.rst`: root toctree for the published training site.
@@ -39,42 +36,33 @@ It is primarily a Sphinx documentation project with a bundled copy of the
   source .venv/bin/activate
   ```
 
-- Optional Pixi setup:
+- Alternative `venv`/`conda` plus `pip` setup:
 
   ```bash
-  pixi install
-  pixi run html
+  /path/to/python3.11+ -m venv .venv
+  source .venv/bin/activate
+  pip install .
   ```
 
 - Optional extras are defined in `pyproject.toml`:
   - `dev` for contributor tooling such as `pre-commit`
   - `notebooks` for local notebook work
   - `mesh_tutorials` for the bundled mesh tutorial workflow
-- `pixi.toml` intentionally flattens these into one optional environment
-  instead of mirroring the `pyproject.toml` extras one-for-one. Keep the
-  matching version constraints aligned across the two files when relevant.
-- Some matching constraints are written differently because the tools use
-  different version-spec syntaxes. In particular, Pixi / Conda-style entries
-  such as `0.5.3.*` and `1.14.4.*` are the tooling-compatible form of the same
-  effective pin represented in `pyproject.toml` as `==0.5.3` and `==1.14.4`;
-  treat that as a syntax difference, not a real environment difference.
-- Although `pyproject.toml` contains `[project]` metadata, the repository is
-  not currently an installable Python package. Do not recommend
-  `pip install .` or `pip install -e .` as the normal setup route.
+- Use `pip install ".[notebooks,mesh_tutorials,dev]"` to install all optional
+  dependency groups in a `venv` or conda environment. For contributor work in
+  that route, `pip install -e ".[notebooks,mesh_tutorials,dev]"` is documented
+  in `README.md`.
+- The `[tool.uv] package = false` setting means `uv sync` installs the
+  dependency environment without installing the project itself. Keep this
+  distinction in mind when comparing `uv` and `pip` setup routes.
 - The mesh tutorial regridding practicals need `esmpy`. The repository
   currently references it in `notebooks/README.md`, the bundled mesh tutorial
   setup instructions, `source/mesh_overview/exercises/practical_exercises.rst`,
-  and the Pixi `mesh-import-check` task. GitHub Pages CI does not install or
-  use `esmpy`; the deploy workflow still builds with `uv sync` and
-  `uv run make clean html`.
-- The regridding package name differs by ecosystem: use `esmf-regrid` for the
-  PyPI / `pyproject.toml` dependency and `iris-esmf-regrid` for the Conda /
-  `pixi.toml` dependency.
-- `sphinxcontrib-quizdown` is not available on conda-forge. Keep it under
-  Pixi's `[pypi-dependencies]` as a Git-sourced package rather than moving it
-  into `[dependencies]`.
-- Dependency policy in `README.md` is explicit: `uv` remains the reference
-  workflow, while `pixi.toml` is an optional alternative.
+  and related notebooks. GitHub Pages CI does not install or use `esmpy`; the
+  deploy workflow still builds with `uv sync` and `uv run make clean html`.
+- Use the PyPI package name `esmf-regrid` in `pyproject.toml`.
+- Dependency policy in `README.md` is explicit: build environments from
+  `pyproject.toml` only, using either `uv` or `venv`/`conda` plus `pip`.
 
 ## Editing guidance
 
@@ -140,9 +128,8 @@ It is primarily a Sphinx documentation project with a bundled copy of the
   training content.
 - Do not change dependency-management conventions casually. If new dependencies
   are necessary, update `pyproject.toml` and keep the README setup instructions
-  consistent with that change. If the change also affects the optional Pixi
-  environment, update `pixi.toml` too.
-- Do not add packaging boilerplate or treat this repository as a distributable
-  Python library unless the user explicitly asks for that change.
+  consistent with that change.
+- Do not add packaging boilerplate or importable Python modules unless the user
+  explicitly asks for that change.
 - Do not commit generated `build/` output, virtual environments, or notebook
   checkpoint files; those are already ignored.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ contributing to this project. By working together under a shared understanding,
 we can continuously improve the project while creating a friendly, inclusive
 space for all contributors.
 
+### Agent Guidance
+
+This repository includes `AGENTS.md` with repository-specific guidance for AI
+coding agents and similar contributor tooling. `CLAUDE.md` is a compatibility
+symlink for tools that look for that filename; it points to the same guidance.
+
 ### Contributors Licence Agreement
 
 Please see the

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -1,0 +1,28 @@
+Glossary
+========
+
+.. glossary::
+
+   Momentum
+      A framework for modelling Earth's environment, developed and used by the
+      Momentum Partnership. Momentum combines model components, science
+      configurations, and technical infrastructure to build prediction and
+      projection systems.
+
+   LFRic Atmosphere
+      The atmospheric model component of Momentum and the successor to the
+      Unified Model for atmosphere modelling. This training site introduces
+      LFRic Atmosphere concepts, infrastructure, meshes, and workflows.
+
+   science configuration
+      A standardised, rigorously tested set of scientific settings for one or
+      more Momentum model components. Science configurations provide a stable
+      basis for weather and climate prediction systems. See
+      :doc:`modelling/introduction/science_config/science_config`.
+
+   working practices
+      The shared development conventions used when contributing to LFRic
+      Atmosphere and related Momentum workflows. In this training site, working
+      practices include repository use, ticket-driven changes, reviews, and
+      standard validation steps. See
+      :doc:`lfric_infrastructure/working_practices`.

--- a/source/index.rst
+++ b/source/index.rst
@@ -36,3 +36,4 @@ Contents of the training course
    mesh_overview/index.rst
    lfric_infrastructure/index.rst
    modelling/index.rst
+   glossary.rst


### PR DESCRIPTION
Supersedes #146: note that #146 has been merged, containing commit a07e00c8ceed08773d65f69ed144bd6bbf1949f6. But since it was a stacking PR, it wasn't merged to main.

This PR is directly merging into main.

Needless to say, AGENTS.md is written by agents for agents. CLAUDE.md symlink is for Claude to be able to recognize the same file. (AGENTS.md is the current standard, but CLAUDE.md appears first and sometimes Claude will "forget" to read AGENTS.md.)

This file is created by driving an agent to explore the repository and summarize the status of the repo. This is also useful for new comers like me for onboarding, which is why I created it in the first place. So please review if the contents is factually accurate—is what is documented here the way you would want anyone (humans and agents alike) to contribute to the project? Obviously it will have some overlap with existing documents such as README.md, but it contains more, such as how to navigate the repo.

One thing might be missing is how you'd want AI contributions be attributed/credited/specified. The current repo doesn't seem to contain this information. Having it recorded here will be most natural.