### PR TITLE
add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      dependencies:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: pip
+    directory: "/"
     schedule:
       interval: monthly
     groups:
-      dependencies:
+      python-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
         patterns:
           - "*"


### PR DESCRIPTION
This would automatically check GitHub Actions' version every month by dependabot. And it will propose PR to bump Actions version, e.g. when this line is used:

```yml
astral-sh/setup-uv@v7
```

This will reduce potential supply chain risks.