### PR TITLE
Add automated pa11y accessibility checks and fix flagged issues (no pixi)

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,59 @@
+name: Accessibility checks
+
+on:
+  pull_request:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pa11y:
+    runs-on: ubuntu-latest
+
+    env:
+      # pa11y-ci ships Puppeteer 9; use the runner's pre-installed Chrome rather
+      # than Puppeteer's (old) bundled Chromium, and skip that download.
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      PUPPETEER_SKIP_DOWNLOAD: "true"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv and Set up Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.11"
+          enable-cache: true
+
+      - name: Install documentation system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes graphviz
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Build documentation
+        run: uv run make clean html
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pa11y-ci
+        run: npm install pa11y-ci
+
+      - name: Run pa11y accessibility checks
+        run: |
+          PUPPETEER_EXECUTABLE_PATH="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium-browser)"
+          if [ -z "$PUPPETEER_EXECUTABLE_PATH" ]; then
+            echo "::error::No Chrome/Chromium binary found on the runner." >&2
+            exit 1
+          fi
+          echo "Using Chrome at: $PUPPETEER_EXECUTABLE_PATH"
+          export PUPPETEER_EXECUTABLE_PATH
+          npx pa11y-ci --config .pa11yci.js

--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -3,7 +3,7 @@ name: Accessibility checks
 on:
   pull_request:
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "23 5 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.egg-info/
 *.bat
 .venv/
+node_modules/
 data-tutorials/
 build/
 **/.ipynb_checkpoints/

--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// pa11y-ci configuration for the built HTML documentation.
+//
+// Discovers every page under build/html and checks it against WCAG 2.1 AA.
+// Build the site first so build/html exists.
+
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const htmlRoot = path.resolve(__dirname, 'build', 'html');
+
+const urls = fs
+  .readdirSync(htmlRoot, { recursive: true })
+  .filter((entry) => entry.endsWith('.html'))
+  // Skip theme assets (e.g. _static/webpack-macros.html is a Jinja template,
+  // not a rendered page); only audit real documentation pages.
+  .filter((entry) => !entry.split(path.sep).includes('_static'))
+  .sort()
+  .map((entry) => pathToFileURL(path.join(htmlRoot, entry)).href);
+
+module.exports = {
+  defaults: {
+    standard: 'WCAG2AA',
+    runners: ['htmlcs'],
+    timeout: 120000,
+    chromeLaunchConfig: {
+      // Use a system Chrome when PUPPETEER_EXECUTABLE_PATH is set (CI),
+      // otherwise fall back to Puppeteer's bundled Chromium (local).
+      executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    },
+  },
+  urls,
+};

--- a/source/_static/accessibility.css
+++ b/source/_static/accessibility.css
@@ -1,0 +1,29 @@
+/*
+ * Accessibility overrides for WCAG 2.1 AA conformance (checked with pa11y).
+ * See issue #133.
+ */
+
+/*
+ * The search field's keyboard-shortcut hint used --pst-color-border (#d1d5da),
+ * a 1.47:1 contrast ratio against the white form background. Use the muted
+ * text colour, which clears 4.5:1 in both the light and dark themes.
+ */
+.bd-search .search-button__kbd-shortcut {
+  color: var(--pst-color-text-muted);
+}
+
+/*
+ * External links on odd ("zebra") table rows had a 4.38:1 contrast ratio: the
+ * teal link colour sat on the grey --pst-color-surface (#f3f4f5). Lighten only
+ * the zebra row background in light mode so links clear 4.5:1 without
+ * restyling other surfaces.
+ */
+html[data-theme="light"] {
+  --pst-color-table-row-zebra-low-bg: #f7f8f9;
+}
+
+@media (prefers-color-scheme: light) {
+  html[data-theme="auto"] {
+    --pst-color-table-row-zebra-low-bg: #f7f8f9;
+  }
+}

--- a/source/_static/accessibility.js
+++ b/source/_static/accessibility.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// Ensure every search form exposes a submit control.
+//
+// The pydata-sphinx-theme search forms (the navbar search dialog and the
+// dedicated search page) ship without a submit button, which fails WCAG 2.1 AA
+// (H32.2) on every page. The search is JavaScript-driven, so adding the button
+// from JavaScript is consistent with the theme. See issue #133.
+(function () {
+  function addSubmitButton(form) {
+    if (
+      form.querySelector(
+        'button[type="submit"], input[type="submit"], input[type="image"]'
+      )
+    ) {
+      return;
+    }
+    var button = document.createElement('button');
+    button.type = 'submit';
+    button.className = 'visually-hidden';
+    button.textContent = 'Search';
+    form.appendChild(button);
+  }
+
+  function enhanceSearchForms() {
+    document.querySelectorAll('form.bd-search').forEach(addSubmitButton);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', enhanceSearchForms);
+  } else {
+    enhanceSearchForms();
+  }
+})();

--- a/source/conf.py
+++ b/source/conf.py
@@ -171,8 +171,8 @@ html_context = {
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ['_static']
-html_css_files = ['nav-collapse.css']
-html_js_files = ['nav-collapse.js']
+html_css_files = ['nav-collapse.css', 'accessibility.css']
+html_js_files = ['nav-collapse.js', 'accessibility.js']
 
 # These URLs are valid learner-facing targets, but cannot be checked reliably
 # from public CI: Cylc Review is an internal hostname and the OASIS site serves


### PR DESCRIPTION
TL;DR: this rewrite #210 without pixi and take a CI only approach. C.f. https://github.com/MetOffice/LFRic-Atmosphere-Training/issues/162#issuecomment-4563719977

## Summary

Resolves #133 by introducing automated [pa11y](https://pa11y.org/) accessibility testing (WCAG 2.1 AA) and fixing every issue it flagged.

- **CI workflow** — `.github/workflows/accessibility.yml` builds the docs with `uv` (matching the existing test workflow) and runs `pa11y-ci` via Node.js 22 (`actions/setup-node`) + `npm install`. No pixi or conda toolchain is involved.
- **pa11y config** — `.pa11yci.js` discovers every page under `build/html` (skipping `_static` assets) and checks against WCAG2AA using the htmlcs runner.
- **Chrome** — the runner's pre-installed Chrome is used via `PUPPETEER_EXECUTABLE_PATH`; bundled-Chromium download is skipped.
- **Fixes** (cherry-picked from `ba1cb37`) — all issues reported in #133:
  - Search field keyboard-shortcut hint contrast 1.47:1 → muted text colour (>= 4.5:1).
  - External links on striped table rows 4.38:1 → lighten the zebra row background (>= 4.5:1).
  - Search forms missing a submit button (H32.2) → inject a visually-hidden submit button on every page via JS.

## Commits

1. `c3e7e7f` Fix accessibility issues flagged by pa11y (CSS + JS + conf.py)
2. `15e326e` Add automated pa11y accessibility CI (without pixi)

## Test plan

- [x] Accessibility workflow passes on this PR.
- [x] `uv run make clean html` builds cleanly.
- [x] pa11y reports 0 errors across all documentation pages.