### PR TITLE
Add output control content to Module 3 (closes #87)

### DIFF
--- a/source/lfric_infrastructure/index.rst
+++ b/source/lfric_infrastructure/index.rst
@@ -12,7 +12,8 @@ on the LFRic Atmosphere model and its underlying components.
    * how the PSyKAl architecture and PSyclone separate scientific code from parallelisation, data movement, and performance concerns;
    * which development tools and repositories you need to work with LFRic source code, configurations, and tests;
    * where the LFRic working practices are documented, including guidance on issues, branches, testing, reviews, and multi-repository development;
-   * where to find support when you are unsure how to apply the working practices.
+   * where to find support when you are unsure how to apply the working practices;
+   * how model output is controlled through XIOS and the ``iodef.xml`` configuration file.
 
 .. admonition:: At the end of this module you should be able to...
 
@@ -21,7 +22,8 @@ on the LFRic Atmosphere model and its underlying components.
    * explain, at a high level, how the algorithm, kernel, and PSy layers fit together in the PSyKAl approach;
    * find the appropriate working-practice guidance before creating issues, branches, tests, reviews, or multi-repository changes;
    * identify the support routes for questions about LFRic development and working practices;
-   * follow the practical workflow for checking out code, compiling, running a simple configuration, making a small change, and using tests as evidence.
+   * follow the practical workflow for checking out code, compiling, running a simple configuration, making a small change, and using tests as evidence;
+   * locate and modify ``iodef.xml`` to control which fields are written, at what frequency, and to which output files.
 
 
 .. toctree::
@@ -31,4 +33,5 @@ on the LFRic Atmosphere model and its underlying components.
    code_repositories.rst
    psykal_infrastructure.rst
    working_practices.rst
+   output_control.rst
    practical_exercises.rst

--- a/source/lfric_infrastructure/output_control.rst
+++ b/source/lfric_infrastructure/output_control.rst
@@ -1,0 +1,146 @@
+.. _iodef.xml example: https://github.com/MetOffice/lfric_apps/blob/main/applications/lfric_atm/example/iodef.xml
+.. _XIOS documentation: https://forge.ipsl.jussieu.fr/ioserver/wiki/documentation
+
+.. _output-control:
+
+Output Control
+==============
+
+LFRic Atmosphere uses `XIOS <https://forge.ipsl.jussieu.fr/ioserver>`_ (XML
+I/O Server) to manage model output. XIOS runs as a separate I/O server process
+alongside the model and writes NetCDF files asynchronously, so that I/O does
+not stall the model computation.
+
+The output is configured entirely through an XML file called ``iodef.xml``. You
+do not need to recompile the model to change what is written, how often, or to
+which files. This makes it straightforward to add diagnostics, change output
+frequencies, or enable checkpointing without touching any Fortran source.
+
+The ``iodef.xml`` file
+----------------------
+
+The `iodef.xml example`_ file in the LFRic Apps repository shows the structure
+used by the LFRic Atmosphere example configuration. A trimmed outline looks like
+this:
+
+.. code-block:: xml
+
+   <simulation>
+     <context id="gungho_atm">
+
+       <!-- Variable, axis, domain, and grid definitions (sourced from metadata) -->
+       <variable_definition src="../metadata/variable_def_main.xml"/>
+       <axis_definition src="../metadata/axis_def_main.xml"/>
+       <domain_definition src="../metadata/domain_def_main.xml"/>
+       <grid_definition src="../metadata/grid_def_main.xml"/>
+
+       <!-- Available field definitions (the model's output catalogue) -->
+       <field_definition src="../metadata/lfric_dictionary.xml"/>
+       <field_definition src="../metadata/field_def_diags.xml"/>
+
+       <!-- Output file definitions -->
+       <file_definition type="one_file" time_counter="none">
+         <file id="lfric_diag" name="lfric_diag"
+               output_freq="6h" convention="UGRID" enabled=".TRUE.">
+           <field field_ref="theta" />
+           <field field_ref="rho" />
+           ...
+         </file>
+       </file_definition>
+
+     </context>
+   </simulation>
+
+The key parts are:
+
+* **Field definitions** — the metadata files list all fields the model *can*
+  write, giving each a unique ``id``. You cannot write a field that is not
+  defined here.
+* **File definitions** — each ``<file>`` element describes one output NetCDF
+  file: its name, output frequency, and the set of fields to include.
+* **Field references** — each ``<field field_ref="..."/>`` inside a
+  ``<file>`` selects a field from the definitions above.
+
+Output files
+------------
+
+The example configuration produces three UGRID NetCDF files:
+
+.. list-table::
+   :header-rows: 1
+
+   * - File
+     - Content
+     - Default frequency
+   * - ``lfric_diag``
+     - Atmospheric diagnostics (temperature, moisture, winds, radiation,
+       surface fields, and more)
+     - 6 hours
+   * - ``lfric_averages``
+     - Time-averaged fields (potential temperature, Exner pressure, wind
+       components)
+     - 12 hours
+   * - ``lfric_initial``
+     - Initial-condition fields written once at the start of the run
+     - Once (first time step)
+
+Checkpoint files (``lfric_checkpoint_write`` and ``lfric_checkpoint_read``)
+are also defined in the file but are disabled by default
+(``enabled=".FALSE."``).
+
+Controlling output
+------------------
+
+**Enabling or disabling a file**
+
+Set ``enabled=".TRUE."`` or ``enabled=".FALSE."`` on a ``<file>`` element:
+
+.. code-block:: xml
+
+   <file id="lfric_averages" name="lfric_averages"
+         output_freq="12h" convention="UGRID" enabled=".FALSE.">
+
+**Changing output frequency**
+
+Edit the ``output_freq`` attribute. Accepted units are ``h`` (hours),
+``min`` (minutes), and ``ts`` (model time steps):
+
+.. code-block:: xml
+
+   <!-- Write every 3 hours instead of 6 -->
+   <file id="lfric_diag" name="lfric_diag"
+         output_freq="3h" convention="UGRID" enabled=".TRUE.">
+
+**Adding a field to an output file**
+
+Look up the field ``id`` in the appropriate metadata file (e.g.
+``metadata/lfric_dictionary.xml`` or ``metadata/field_def_diags.xml``) and add
+a ``<field field_ref="..."/>`` line inside the ``<file>`` block:
+
+.. code-block:: xml
+
+   <file id="lfric_diag" name="lfric_diag"
+         output_freq="6h" convention="UGRID" enabled=".TRUE.">
+     <field field_ref="theta" />
+     <field field_ref="exner" />   <!-- newly added -->
+     ...
+   </file>
+
+**Removing a field**
+
+Delete or comment out the corresponding ``<field field_ref="..."/>`` line.
+
+Output format
+-------------
+
+LFRic output files follow the `CF conventions <https://cfconventions.org>`_
+and use the `UGRID conventions <https://ugrid-conventions.github.io/ugrid-conventions/>`_
+to describe fields on unstructured meshes. These files can be read with
+Python libraries such as `Iris <https://scitools-iris.readthedocs.io>`_ and
+`iris-esmf-regrid <https://iris-esmf-regrid.readthedocs.io>`_.
+
+.. seealso::
+
+   * `iodef.xml example`_ in the LFRic Apps repository.
+   * `XIOS documentation`_ for the full XIOS XML reference.
+   * The :ref:`iris.basics` tutorial for reading and plotting LFRic NetCDF output.

--- a/source/lfric_infrastructure/practical_command_line.rst
+++ b/source/lfric_infrastructure/practical_command_line.rst
@@ -18,6 +18,7 @@ Practical 1: Run the model from command line
 
    * Build and run the LFRic Atmosphere as a command line application.
    * Add custom messages to the model’s standard output.
+   * Modify the output configuration to change what is written and how often.
 
 Step 1: Compile the model
 +++++++++++++++++++++++++
@@ -123,7 +124,9 @@ The code contains an `LFRic example`_ configuration containing:
 
    The NetCDF output is configured by the file ``iodef.xml``
    in the example directory. It controls the output streams,
-   filenames, written fields, and output frequency.
+   filenames, written fields, and output frequency. See
+   :ref:`output-control` for a full explanation of the file
+   structure and how to modify it.
 
 Step 3: Modify the Model
 ++++++++++++++++++++++++
@@ -192,3 +195,43 @@ To gain familiarity with the model:
    version control. This ensures traceability and supports collaborative
    development. You'll learn how to document and manage your code changes
    using tickets and branches in Practical 3.
+
+Step 4: Modify the Output
++++++++++++++++++++++++++
+
+Unlike the model source code, the output configuration in ``iodef.xml`` does
+not require a recompile. You can change what is written and how often by
+editing the XML, then re-running the model.
+
+1. Open ``applications/lfric_atm/example/iodef.xml`` and find the
+   ``lfric_averages`` file definition.
+
+2. Change its ``output_freq`` from ``12h`` to ``6h`` so that averaged fields
+   are written at the same frequency as the diagnostics.
+
+3. Add the ``rho`` field to the ``lfric_averages`` file with a time average
+   operation:
+
+   .. hint::
+      :collapsible: closed
+
+      Inside the ``lfric_averages`` ``<file>`` block, add:
+
+      .. code-block:: xml
+
+         <field field_ref="rho" operation="average" />
+
+4. Re-run the model (no recompile needed):
+
+   .. code-block:: console
+
+      ../bin/lfric_atm configuration.nml > log.txt
+
+5. Check that the ``lfric_averages.nc`` file now contains a ``rho`` variable
+   and has more time steps than before.
+
+.. seealso::
+
+   :ref:`output-control` explains the full ``iodef.xml`` structure, including
+   how to enable checkpoint files and how to reference fields from the LFRic
+   metadata catalogues.


### PR DESCRIPTION
## Summary

- Adds a new `output_control.rst` page to Module 3 explaining how LFRic Atmosphere controls model output through XIOS and `iodef.xml`
- Covers the file structure, the three default output files (`lfric_diag`, `lfric_averages`, `lfric_initial`), and how to enable/disable files, change output frequency, and add/remove fields
- Adds Step 4 to Practical 1 so learners immediately apply this knowledge by editing `iodef.xml` and re-running the model without recompiling
- Updates Module 3 learning objectives to include output control

Closes #87

## Test plan

- [x] Sphinx build succeeds with no warnings
- [ ] Reviewer to check that `output_control.rst` accurately represents XIOS/iodef.xml behaviour
- [ ] Reviewer to verify Step 4 instructions are achievable with the example configuration