### PR TITLE
Add iodef.xml output control reference page and practical tasks

### DIFF
--- a/source/lfric_infrastructure/index.rst
+++ b/source/lfric_infrastructure/index.rst
@@ -12,7 +12,8 @@ on the LFRic Atmosphere model and its underlying components.
    * how the PSyKAl architecture and PSyclone separate scientific code from parallelisation, data movement, and performance concerns;
    * which development tools and repositories you need to work with LFRic source code, configurations, and tests;
    * where the LFRic working practices are documented, including guidance on issues, branches, testing, reviews, and multi-repository development;
-   * where to find support when you are unsure how to apply the working practices.
+   * where to find support when you are unsure how to apply the working practices;
+   * how model output is controlled through XIOS and the ``iodef.xml`` configuration file.
 
 .. admonition:: At the end of this module you should be able to...
 
@@ -21,7 +22,8 @@ on the LFRic Atmosphere model and its underlying components.
    * explain, at a high level, how the algorithm, kernel, and PSy layers fit together in the PSyKAl approach;
    * find the appropriate working-practice guidance before creating issues, branches, tests, reviews, or multi-repository changes;
    * identify the support routes for questions about LFRic development and working practices;
-   * follow the practical workflow for checking out code, compiling, running a simple configuration, making a small change, and using tests as evidence.
+   * follow the practical workflow for checking out code, compiling, running a simple configuration, making a small change, and using tests as evidence;
+   * locate and modify ``iodef.xml`` to control which fields are written, at what frequency, and to which output files.
 
 
 .. toctree::
@@ -31,4 +33,5 @@ on the LFRic Atmosphere model and its underlying components.
    code_repositories.rst
    psykal_infrastructure.rst
    working_practices.rst
+   output_control.rst
    practical_exercises.rst

--- a/source/lfric_infrastructure/output_control.rst
+++ b/source/lfric_infrastructure/output_control.rst
@@ -1,0 +1,213 @@
+.. _iodef.xml example: https://github.com/MetOffice/lfric_apps/blob/main/applications/lfric_atm/example/iodef.xml
+.. _XIOS documentation: https://ipsl.pages.in2p3.fr/projets/xios-projects/xios/
+
+.. _output-control:
+
+Output Control
+==============
+
+LFRic Atmosphere uses `XIOS <https://gitlab.in2p3.fr/ipsl/projets/xios-projects/xios>`_ (XML
+I/O Server) to manage model output. XIOS runs as a separate I/O server process
+alongside the model and writes NetCDF files asynchronously, so that I/O does
+not stall the model computation.
+
+Output control is split between an XML file called ``iodef.xml`` and the
+runtime namelist. The XML file describes the XIOS files, fields, frequencies,
+and grid conventions. The namelist controls which categories of output are
+active in a particular run. You do not need to recompile the model to change
+these settings.
+
+The ``iodef.xml`` file
+----------------------
+
+The `iodef.xml example`_ file in the LFRic Apps repository shows the structure
+used by the LFRic Atmosphere example configuration.
+
+.. note::
+
+   The file names, fields, and frequencies described on this page reflect the
+   example configuration on the ``main`` branch at the time of writing. The
+   linked `iodef.xml example`_ is always authoritative — check it if the
+   details have moved on.
+
+A trimmed outline looks like this:
+
+.. code-block:: xml
+
+   <simulation>
+     <context id="gungho_atm">
+
+       <!-- Variable, axis, domain, and grid definitions (sourced from metadata) -->
+       <variable_definition src="../metadata/variable_def_main.xml"/>
+       <axis_definition src="../metadata/axis_def_main.xml"/>
+       <domain_definition src="../metadata/domain_def_main.xml"/>
+       <grid_definition src="../metadata/grid_def_main.xml"/>
+
+       <!-- Available field definitions (the model's output catalogue) -->
+       <field_definition src="../metadata/lfric_dictionary.xml"/>
+       <field_definition src="../metadata/field_def_diags.xml"/>
+
+       <!-- Output file definitions -->
+       <file_definition type="one_file" time_counter="none">
+         <file id="lfric_diag" name="lfric_diag"
+               output_freq="6h" convention="UGRID" enabled=".TRUE.">
+           <field field_ref="theta" />
+           <field field_ref="rho" />
+           ...
+         </file>
+       </file_definition>
+
+     </context>
+   </simulation>
+
+The key parts are:
+
+* **Field definitions** — the metadata files list all fields the model *can*
+  write, giving each a unique ``id``. You cannot write a field that is not
+  defined here.
+* **File definitions** — each ``<file>`` element describes one output NetCDF
+  file: its name, output frequency, and the set of fields to include.
+* **Field references** — each ``<field field_ref="..."/>`` inside a
+  ``<file>`` selects a field from the definitions above.
+* **Grid conventions** — the ``convention`` attribute selects the output
+  convention for the file, while field metadata such as ``grid_ref`` describes
+  how fields sit on the mesh.
+
+The namelist then selects which of these definitions are used by the canned
+configuration. For example, the default ``configuration.nml`` selects only the
+main diagnostic output stream:
+
+.. code-block:: fortran
+
+   &io
+   diag_active_files='lfric_diag',
+   write_diag=.true.,
+   write_initial=.false.
+   /
+
+Output files
+------------
+
+The example ``iodef.xml`` contains these file definitions:
+
+.. list-table::
+   :header-rows: 1
+
+   * - File definition
+     - Purpose
+     - Frequency
+     - Default run status
+   * - ``lfric_diag``
+     - Instantaneous atmospheric diagnostics.
+     - 6 hours
+     - Written by default because ``diag_active_files`` selects it.
+   * - ``lfric_averages``
+     - Time-averaged diagnostics.
+     - 12 hours
+     - Defined and enabled in XML, but not selected by the default
+       ``diag_active_files`` namelist entry.
+   * - ``lfric_initial``
+     - Initial-condition diagnostics.
+     - Once, on the first time step
+     - Defined and enabled in XML, but not written in the default run (which
+       sets ``write_initial=.false.``).
+   * - ``lfric_checkpoint_write``
+     - Checkpoint output.
+     - 1 time step
+     - Disabled by default.
+   * - ``lfric_checkpoint_read``
+     - Checkpoint input.
+     - 1 time step
+     - Disabled by default and opened in read mode.
+   * - ``lfric_fd_dump``
+     - Full dump output.
+     - 1 time step
+     - Disabled by default.
+   * - ``read_lfric_fd_dump``
+     - Full dump input.
+     - 1 time step
+     - Disabled by default and opened in read mode.
+
+The main diagnostic outputs use the UGRID convention:
+
+.. list-table::
+   :header-rows: 1
+
+   * - File definition
+     - Example content
+   * - ``lfric_diag``
+     - Atmospheric diagnostics (temperature, moisture, winds, radiation,
+       surface fields, and more)
+   * - ``lfric_averages``
+     - Time-averaged fields (potential temperature, Exner pressure, wind
+       components)
+   * - ``lfric_initial``
+     - Initial-condition fields written once at the start of the run
+
+Controlling output
+------------------
+
+**Enabling or disabling a file**
+
+Set ``enabled=".TRUE."`` or ``enabled=".FALSE."`` on a ``<file>`` element.
+For diagnostic files, also select the file in ``configuration.nml``:
+
+.. code-block:: xml
+
+   <file id="lfric_averages" name="lfric_averages"
+         output_freq="12h" convention="UGRID" enabled=".TRUE.">
+
+.. code-block:: fortran
+
+   diag_active_files='lfric_diag','lfric_averages',
+
+**Changing output frequency**
+
+Edit the ``output_freq`` attribute. Accepted units include ``ts`` (model time
+steps), ``h`` (hours), ``d`` (days), and ``mi`` (minutes):
+
+.. code-block:: xml
+
+   <!-- Write every 3 hours instead of 6 -->
+   <file id="lfric_diag" name="lfric_diag"
+         output_freq="3h" convention="UGRID" enabled=".TRUE.">
+
+**Adding a field to an output file**
+
+Look up the field ``id`` in the appropriate metadata file (e.g.
+``metadata/lfric_dictionary.xml`` or ``metadata/field_def_diags.xml``) and add
+a ``<field field_ref="..."/>`` line inside the ``<file>`` block:
+
+.. code-block:: xml
+
+   <file id="lfric_diag" name="lfric_diag"
+         output_freq="6h" convention="UGRID" enabled=".TRUE.">
+     <field field_ref="theta" />
+     <field field_ref="exner" />   <!-- newly added -->
+     ...
+   </file>
+
+The field must be one the model actually computes and sends to XIOS — in
+practice, one already produced by the active diagnostic system. You cannot
+write a field that the model does not provide, even if it is defined in the
+metadata.
+
+**Removing a field**
+
+Delete or comment out the corresponding ``<field field_ref="..."/>`` line.
+
+Output format
+-------------
+
+LFRic NetCDF output follows the `CF conventions <https://cfconventions.org>`_.
+The atmospheric diagnostic files also use the `UGRID conventions
+<https://ugrid-conventions.github.io/ugrid-conventions/>`_ to describe fields
+on unstructured meshes. These files can be read with Python libraries such as
+`Iris <https://scitools-iris.readthedocs.io>`_ and `iris-esmf-regrid
+<https://iris-esmf-regrid.readthedocs.io>`_.
+
+.. seealso::
+
+   * `iodef.xml example`_ in the LFRic Apps repository.
+   * `XIOS documentation`_ for the full XIOS XML reference.
+   * The :ref:`iris.basics` tutorial for reading and plotting LFRic NetCDF output.

--- a/source/lfric_infrastructure/practical_command_line.rst
+++ b/source/lfric_infrastructure/practical_command_line.rst
@@ -240,7 +240,7 @@ first:
 
    cd applications/lfric_atm/example
 
-1. Open ``applications/lfric_atm/example/configuration.nml`` and add the
+1. Open ``configuration.nml`` and add the
    ``lfric_averages`` file to ``diag_active_files``:
 
    .. code-block:: fortran
@@ -267,7 +267,7 @@ first:
 
       mv lfric_averages.nc lfric_averages_12h.nc
 
-5. Open ``applications/lfric_atm/example/iodef.xml`` and find the
+5. Open ``iodef.xml`` and find the
    ``lfric_averages`` file definition.
 
 6. Change its ``output_freq`` from ``12h`` to ``6h`` so that averaged fields

--- a/source/lfric_infrastructure/practical_command_line.rst
+++ b/source/lfric_infrastructure/practical_command_line.rst
@@ -2,6 +2,7 @@
 
 .. _example mesh file: https://code.metoffice.gov.uk/trac/lfric_apps/browser/main/trunk/applications/lfric_atm/example
 .. _lfric example: https://github.com/MetOffice/lfric_apps/blob/main/applications/lfric_atm/example
+.. _iodef.xml example: https://github.com/MetOffice/lfric_apps/blob/main/applications/lfric_atm/example/iodef.xml
 
 .. Not migrated yet
 .. _LFRic Development Environment: https://code.metoffice.gov.uk/trac/lfric/wiki/DevelopmentEnvironment
@@ -17,7 +18,9 @@ Practical 1: Run the model from command line
 .. admonition:: Aims
 
    * Build and run the LFRic Atmosphere as a command line application.
-   * Add custom messages to the model’s standard output.
+   * Explore how model output is controlled via the ``iodef.xml`` configuration file.
+   * Modify the output configuration to change what is written and how often.
+   * Add custom messages to the model's standard output.
 
 Step 1: Compile the model
 +++++++++++++++++++++++++
@@ -100,7 +103,7 @@ The code contains an `LFRic example`_ configuration containing:
       cd applications/lfric_atm/example
 
 
-2. Run the example with a “single-column” configuration:
+2. Run the example with a "single-column" configuration:
 
    .. code-block:: console
 
@@ -116,14 +119,44 @@ The code contains an `LFRic example`_ configuration containing:
 
    * Run time profiling?
    * Checksums of model fields after the last time step (for tests)?
-   * Three NetCDF files. How to open NetCDF files is covered in the
-     :ref:`iris.basics` tutorial?
+   * NetCDF output files. How to open NetCDF files is covered in the
+     :ref:`iris.basics` tutorial.
 
-.. note::
+   Inspect the NetCDF header for the main diagnostic file:
 
-   The NetCDF output is configured by the file ``iodef.xml``
-   in the example directory. It controls the output streams,
-   filenames, written fields, and output frequency.
+   .. code-block:: console
+
+      ncdump -h lfric_diag.nc | less
+
+   ``ncdump`` is part of the NetCDF tools, available in the Met Office
+   ``lfric`` environment. On other platforms, install the NetCDF utilities or
+   use the :ref:`iris.basics` Python workflow instead.
+
+4. Explore the NetCDF output configuration:
+
+   The NetCDF output is controlled by both ``iodef.xml`` and the ``&io``
+   namelist settings in ``configuration.nml`` (see the `iodef.xml example`_
+   and :ref:`output-control`). Open both files and answer the following:
+
+   * How many ``<file>`` definitions are configured in ``iodef.xml``, and
+     what are their names?
+   * Which file definitions are enabled, disabled, or opened in read mode?
+   * Which diagnostic output files are selected by ``diag_active_files`` in
+     ``configuration.nml``?
+   * Roughly how many fields does ``lfric_diag`` write, and what are a few
+     examples? How does its field list compare with ``lfric_averages``?
+   * At what frequency is output written?
+
+   .. hint::
+      :collapsible: closed
+
+      Look for ``<file>`` elements — each defines one XIOS file. The ``name``
+      attribute gives the output filename. ``<field>`` elements nested inside
+      each ``<file>`` block list the model fields written to that file. The
+      ``output_freq`` attribute on ``<file>`` sets how often output is
+      written. The ``enabled`` and ``mode`` attributes describe the XML file
+      definition, while namelist settings such as ``diag_active_files`` and
+      ``write_initial`` control which definitions are used by this run.
 
 Step 3: Modify the Model
 ++++++++++++++++++++++++
@@ -192,3 +225,86 @@ To gain familiarity with the model:
    version control. This ensures traceability and supports collaborative
    development. You'll learn how to document and manage your code changes
    using tickets and branches in Practical 3.
+
+Step 4: Modify the Output
++++++++++++++++++++++++++
+
+Unlike the model source code, the output configuration does not require a
+recompile. You can change what is written and how often by editing
+``configuration.nml`` and ``iodef.xml``, then re-running the model.
+
+If you are not still in the example directory after recompiling, return to it
+first:
+
+.. code-block:: console
+
+   cd applications/lfric_atm/example
+
+1. Open ``applications/lfric_atm/example/configuration.nml`` and add the
+   ``lfric_averages`` file to ``diag_active_files``:
+
+   .. code-block:: fortran
+
+      diag_active_files='lfric_diag','lfric_averages',
+
+2. Re-run the model to create a baseline ``lfric_averages.nc`` file at the
+   default 12-hour output frequency:
+
+   .. code-block:: console
+
+      rm -f lfric_averages.nc
+      ../bin/lfric_atm configuration.nml > log_averages_12h.txt
+
+3. Inspect the file and note the time dimension and variable names:
+
+   .. code-block:: console
+
+      ncdump -h lfric_averages.nc | less
+
+4. Keep the baseline file so that you can compare it with the next run:
+
+   .. code-block:: console
+
+      mv lfric_averages.nc lfric_averages_12h.nc
+
+5. Open ``applications/lfric_atm/example/iodef.xml`` and find the
+   ``lfric_averages`` file definition.
+
+6. Change its ``output_freq`` from ``12h`` to ``6h`` so that averaged fields
+   are written at the same frequency as the diagnostics.
+
+7. Add the ``rho`` field to the ``lfric_averages`` file with a time average
+   operation:
+
+   .. hint::
+      :collapsible: closed
+
+      Inside the ``lfric_averages`` ``<file>`` block, add:
+
+      .. code-block:: xml
+
+         <field field_ref="rho" operation="average" />
+
+8. Re-run the model (no recompile needed):
+
+   .. code-block:: console
+
+      ../bin/lfric_atm configuration.nml > log_averages_6h.txt
+
+9. Compare the headers from the old and new averages files:
+
+   .. code-block:: console
+
+      ncdump -h lfric_averages_12h.nc | grep -E "time =|rho"
+      ncdump -h lfric_averages.nc | grep -E "time =|rho"
+
+   Check that the new ``lfric_averages.nc`` file contains a ``rho`` variable
+   and has more time records than the 12-hour baseline file. With the default
+   24-hour run, the 12-hour baseline should hold 2 time records and the 6-hour
+   file 4.
+
+.. seealso::
+
+   :ref:`output-control` explains the full ``iodef.xml`` structure, including
+   how to enable checkpoint files and how to reference fields from the LFRic
+   metadata catalogues.


### PR DESCRIPTION
## Summary

Combines and resolves #84 and #87, which both stem from the same PR #81 review
comment asking for better coverage of model output control.

- Adds an **Output Control** reference page (`output_control.rst`) to Module 3.
  It explains that output control is split between `iodef.xml` (XIOS files,
  fields, frequencies, grid conventions) and the runtime `&io` namelist (which
  definitions are active in a given run), documents the file definitions in the
  example configuration, and shows how to enable/disable a file, change its
  output frequency, and add/remove fields. Output formats (CF + UGRID) and
  links to Iris are included.
- Extends **Practical 1** (Run the model from command line):
  - **Step 2** — students dump the `lfric_diag` NetCDF header with `ncdump` and
    answer questions about the `iodef.xml` file definitions and the `&io`
    namelist (`diag_active_files`, and which files are enabled, disabled, or
    opened in read mode) before changing anything (understand first).
  - **Step 4** — students activate `lfric_averages` via `diag_active_files`,
    capture a 12-hour baseline, then change `output_freq` to 6h and add the
    `rho` field, re-run without recompiling, and compare NetCDF headers to
    confirm the new field and the increase from 2 to 4 time records.
- Updates `index.rst` learning objectives and toctree. XIOS links point to the
  current GitLab project (`gitlab.in2p3.fr/ipsl/projets/xios-projects/xios`)
  and its documentation site, since the old `forge.ipsl.jussieu.fr` server is
  deprecated.

## Commits

Two atomic commits, each self-contained and CI-clean:

1. `Add Output Control reference page for XIOS/iodef.xml (closes #87)` — the
   page and the `index.rst` updates.
2. `Extend command line practical with iodef.xml exploration and modification (closes #84)`.

## Verification

Checked against the live `iodef.xml` and `configuration.nml` on `lfric_apps@main`:
the file-definition table, the `&io` namelist entries, and the run length
(`dt=1200s` × 72 steps = 24 h, so `lfric_averages` goes from 2 to 4 records when
`output_freq` changes 12h → 6h).

- [x] Sphinx build succeeds with no warnings (`-Wn`; `output-control` and
      `iris.basics` cross-references resolve)
- [x] `linkcheck` passes, including the new XIOS GitLab + docs links
- [x] Collapsible hints render as expected
- [x] `seealso` block in Step 4 cross-links to the reference page correctly
- [x] Module 3 table of contents shows the Output Control page in the right position
