### PR TITLE
Check rst source line length to be at most 93

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check rst source line length to be at most 93
+        run: |
+          max_line_length=$(find source -name '*.rst' -exec awk 'NF > max {max = NF} END {print max}' {} +)
+          test "${max_line_length}" -le 93
+
       - name: Install uv and Set up Python
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
It has been brought up in various PRs (e.g. https://github.com/MetOffice/LFRic-Atmosphere-Training/pull/219#pullrequestreview-4388169260) that the RST source files column width are sometimes too long.
This add a check that the rst source is at most 93, any longer would makes it fails the CI.
I have considered proper RST formatter/linter such as docstrfmt or rstfmt, but they will reformat all lines in all files, not suitable to perform to all files automatically as that would creates merge conflicts when people are actively developing.
So the simplest solution is to perform an automatic check and flag the issue immediately when such problem arise, hopefully reduces back and forth communications in a PR.

P.S. The magic no. 93 arises as the current longest line in the repo. While 72/80/120 are more popular choices, this is chosen to minimize the amount of fixing needed on day 1.