### PR TITLE
Updated content for workshop 2026-06-08

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@
 | foroughgoudarzi  | Forough Goudarzi       | Met Office            | 2026-05-31 |
 | stephenworsley   | Stephen Worsley        | Met Office            | 2026-06-03 |
 | menonarathy      | Arathy Menon           | Met Office            | 2026-06-04 |
+| pp-mo            | Patrick Peglar         | Met Office            | 2026-06-05 |

--- a/notebooks/iris-mesh-tutorial/notebooks/06_Exercise_01.ipynb
+++ b/notebooks/iris-mesh-tutorial/notebooks/06_Exercise_01.ipynb
@@ -48,19 +48,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "0090a1de",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Kernel Python: /Users/lb788/miniconda3/envs/lfric-mesh/bin/python\n",
-      "Backend check: OK\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Notebook warning controls\n",
     "import warnings\n",
@@ -119,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "3febf87a-a9ee-4047-890c-e200d55de06c",
    "metadata": {},
    "outputs": [],
@@ -138,34 +129,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d088822-3671-44ae-8f81-27df368a185e",
+   "id": "8d745240-171f-479b-b3df-7d05d63e21fd",
    "metadata": {},
    "source": [
-    "The [pv_conversions](./pv_conversions.py) script contains two functions which convert LFRic cubes to pyvista objects. Load these two functions:"
+    "----\n",
+    "NOTE: the [`iris.experimental.geovista.cube_to_polydata`](https://scitools-iris.readthedocs.io/en/v3.15.0/generated/api/iris.experimental.geovista.html#iris.experimental.geovista.cube_to_polydata) function is provided to convert a cube to a pyvista `polydata` object.  We will be using that ..."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "1cd00d6a-e10a-4af1-870d-1874cead45c2",
-   "metadata": {},
+   "execution_count": null,
+   "id": "b2256286-564e-4b52-b0c9-ade158da8a82",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "from support.pv_conversions import pv_from_lfric_cube"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fcba4bf8-d380-463c-abde-09d22f668ea9",
-   "metadata": {},
-   "source": [
-    "**Step 2** Use iris.load_cube to load in the LFRic data, and select the diagnostic 'surface_air_pressure'. Print the cube - is it a mesh or grid?"
+    "from iris.experimental.geovista import cube_to_polydata"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "b8eb1ce2-2160-4c3f-b97b-4b09946d84cc",
+   "execution_count": null,
+   "id": "a4514cca-3c25-481d-bcab-b0434ffddd73",
    "metadata": {
     "tags": []
    },
@@ -176,7 +162,31 @@
     "lfric_path = data_path + 'u-ct674_20210324T0000Z_lf_ugrid.nc'\n",
     "um_path = data_path + 'u-ct674_20210324T0000Z_um_latlon.nc'\n",
     "\n",
-    "# Continue here with importing the data... \n"
+    "# Continue here with importing the data... "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcba4bf8-d380-463c-abde-09d22f668ea9",
+   "metadata": {},
+   "source": [
+    "**Step 2**  \n",
+    "Use iris.load_cube to load in the LFRic data, and select the diagnostic `\"surface_air_pressure\"`.  \n",
+    "*Print* the cube -- is it a mesh or grid, and how do you know ?\n",
+    "\n",
+    "(hint:  use `iris.load_cube(path, \"data_name\")`  -- see [Strict loading](https://scitools-iris.readthedocs.io/en/v3.15.0/user_manual/tutorial/loading_iris_cubes.html#strict-loading) )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8eb1ce2-2160-4c3f-b97b-4b09946d84cc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Code here..."
    ]
   },
   {
@@ -186,7 +196,8 @@
     "tags": []
    },
    "source": [
-    "**Step 4** Select the first timestep from the data so we have a 2D cube"
+    "**Step 3** Extract the first timestep from the data so we have a 2D cube  \n",
+    "( hint: index cubes with [] -- see [Cube indexing](https://scitools-iris.readthedocs.io/en/v3.15.0/user_manual/tutorial/subsetting_a_cube.html#cube-indexing) )"
    ]
   },
   {
@@ -197,14 +208,18 @@
     "tags": []
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "fee7cd45-86b3-45a6-a158-811244de2cb0",
    "metadata": {},
    "source": [
-    "**Step 3** Transform the LFRic cube into a pyvista object using one of the functions from pv_conversions"
+    "**Step 4** Transform the LFRic cube into a pyvista object using the Iris `cube_to_polydata` function\n",
+    "\n",
+    "(Note: [`Geovista.bridge.Transform`](https://geovista.readthedocs.io/en/latest/reference/generated/api/geovista/bridge/#geovista.bridge.Transform) does most of the work. See the code [here](https://scitools-iris.readthedocs.io/en/v3.15.0/_modules/iris/experimental/geovista.html#cube_to_polydata))"
    ]
   },
   {
@@ -213,16 +228,25 @@
    "id": "5cd7a318-9462-4e6f-99b6-73ab2033a6c0",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "6689db53-29a9-44ce-9c55-15093e36959c",
    "metadata": {},
    "source": [
-    "**Step 5** Use GeoPlotter to plot the data using PyVista. You will need to use plotter.show() to display the plot.\n",
+    "**Step 5**  \n",
+    "Use GeoPlotter to plot the data using PyVista.  \n",
+    "You can now observe Surface Air Pressure on a 3D globe.  \n",
     "\n",
-    "You can now observe Surface Air Pressue on a 3D globe. "
+    "(hints:  \n",
+    "create a `GeoPlotter()` ;  \n",
+    "use its `.add_mesh(polydata)` ;  \n",
+    "finally use it's `.show()`  \n",
+    "  -- see [Geovista basic example](https://geovista.readthedocs.io/en/latest/quick_start.html#oisst-avhrr) (but you don't need a color-bar)  \n",
+    ")"
    ]
   },
   {
@@ -233,16 +257,53 @@
     "tags": []
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68da64ce-30ee-442d-8c1f-b1614925bae4",
+   "metadata": {},
+   "source": [
+    "**( Step \"5(a)\" )**  \n",
+    "In fact, the simplest way of plotting is just to use `polydata.plot()`.  \n",
+    "Try that."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "415e4bd3-4a1c-46e0-a9c3-4c18471939ff",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "Now, lets regrid some LFRic data onto a lat/lon grid"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "56581cce-68a2-46e1-b8e3-4c6c6fa2650d",
    "metadata": {},
    "source": [
-    "**Step 6** Now, lets regrid some LFRic data onto a lat/lon grid\n",
+    "**Step 6**\n",
+    "Use iris.load_cube to load the reference grid and print the cube.  \n",
+    "You can use the equivalent UM data loaded above for this.  \n",
     "\n",
-    "Use iris.load_cube to load the reference grid and print the cube. You can use the equivelent UM data loaded above for this. "
+    "(hints:  \n",
+    "load from `um_path`;  \n",
+    "sub-index as required to get a 2D \"grid\" cube  \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f554c53-e4d5-49af-a782-2f65103caa91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "um_cube = iris.load_cube(um_path, \"surface_air_pressure\")\n",
+    "print(um_cube)"
    ]
   },
   {
@@ -251,14 +312,20 @@
    "id": "01c3db83-dd81-4722-87a6-f4c76c8c702d",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "b668e1ea-f9cf-4b79-82a0-6b4d8758d7be",
    "metadata": {},
    "source": [
-    "**Step 7** Create a regridder by using ESMFAreaWeighted. Make sure the mesh and grid are the correct way round, consult the [regridding section](./04_Regridding.ipynb) of the notebooks for help."
+    "**Step 7**  \n",
+    "Create an Iris regridding scheme using `ESMFAreaWeighted`.  \n",
+    "Consult the iris-esmf-regrid documentation [here](https://iris-esmf-regrid.readthedocs.io/en/latest/_api_generated/esmf_regrid.schemes.html#esmf_regrid.schemes.ESMFAreaWeighted)\n",
+    "\n",
+    "(hint: `ESMFAreaWeighted` doesn't _require_ any arguments)"
    ]
   },
   {
@@ -267,14 +334,20 @@
    "id": "2bfa4b13-9675-4b10-88a0-3810c528d476",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "bdaa14ff-2df3-4868-b32b-bd62ffb11830",
    "metadata": {},
    "source": [
-    "**Step 8** Now, regrid the LFRic data using the regridder you created. Print the result - is your LFRic data regridded?"
+    "**Step 8**  \n",
+    "Now, regrid the LFRic data using the Iris scheme you created.  \n",
+    "*Print* the result -- is your LFRic data regridded?\n",
+    "\n",
+    "(hint: use `cube.regrid(grid_cube, scheme)` )"
    ]
   },
   {
@@ -283,14 +356,16 @@
    "id": "005b09cd-1f13-4825-87be-8f16ec08cb1b",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "744e9bbb-6046-4630-9a36-4f77d4fcca07",
    "metadata": {},
    "source": [
-    "**Step 9** Using qplt.pcolormesh plot the regridded LFRic data"
+    "**Step 9** Use `qplt.pcolormesh` to plot the regridded LFRic data"
    ]
   },
   {
@@ -301,15 +376,25 @@
     "tags": []
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10e19a12-d8c2-4888-8b4e-2c211e8bc1e0",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "We can use the UM data loaded as reference for the regridding to compare to the reggrided LFRic data.  "
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "10daa415-67ef-455b-8311-a43cd9329f52",
    "metadata": {},
    "source": [
-    "**Step 10** We can use the UM data loaded as reference for the regridding to compare to the reggrided LFRic data.\\\n",
-    "Now select the first timestep of the UM data loaded in step 6"
+    "**Step 10**  Select the first timestep of the UM data loaded in step 6"
    ]
   },
   {
@@ -318,14 +403,18 @@
    "id": "c8624c43-82a2-427e-8482-23bd08d396e2",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "df92fa5e-10b6-4aed-82c6-534b36b65e07",
    "metadata": {},
    "source": [
-    "**Step 11** Now calulate the difference between the LFRic regridded data and native UM data"
+    "**Step 11**  Calculate the difference between the LFRic regridded data and native UM data  \n",
+    "\n",
+    "(hint: cubes can be simply subtracted -- see [Cube Maths](https://scitools-iris.readthedocs.io/en/v3.15.0/user_manual/tutorial/cube_maths.html) )"
    ]
   },
   {
@@ -334,21 +423,34 @@
    "id": "802b6161-73cd-46bd-ad13-ad3d1701cf18",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "41d722a5-89cf-4c42-b712-e260e45d36dc",
    "metadata": {},
    "source": [
-    "**Step 12** Now plot the original UM data and the regridded LFRic data and the difference side by side. \\\n",
-    "(hint: use plt.subplot(1,3,1) and try adding a title and coastlines to the plot)"
+    "**Step 12** Plot the original UM data and the regridded LFRic data and the difference side by side.  \n",
+    "\n",
+    "(hint: use `plt.subplot(1,3,1)`, and try adding a title and coastlines to the plot.)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "1ac432aa-f7db-4b88-b58d-b1b631943f37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Code here..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43055fe7-b84b-4fbe-b7f2-3a8c7846810a",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/iris-mesh-tutorial/notebooks/07_Exercise_02.ipynb
+++ b/notebooks/iris-mesh-tutorial/notebooks/07_Exercise_02.ipynb
@@ -48,19 +48,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "5ffa1f66",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Kernel Python: /Users/lb788/miniconda3/envs/lfric-mesh/bin/python\n",
-      "Backend check: OK\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Notebook warning controls\n",
     "import warnings\n",
@@ -123,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5b4e9653",
    "metadata": {
     "tags": []
@@ -147,20 +138,20 @@
    "id": "69d50af6",
    "metadata": {},
    "source": [
-    "The [pv_conversions](./pv_vonversions.py) script contains two functions which convert LFRic cubes to pyvista objects. Load these two functions:"
+    "----\n",
+    "NOTE: the [`iris.experimental.geovista.cube_to_polydata`](https://scitools-iris.readthedocs.io/en/v3.15.0/generated/api/iris.experimental.geovista.html#iris.experimental.geovista.cube_to_polydata) function is provided to convert a cube to a pyvista `polydata` object.  We will be using that ..."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "30e5c42d",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "from support.pv_conversions import pv_from_lfric_cube\n",
-    "from support.pv_conversions import pv_from_um_cube"
+    "from iris.experimental.geovista import cube_to_polydata"
    ]
   },
   {
@@ -168,12 +159,13 @@
    "id": "0035d108-8c91-4fd9-9ce3-d0568118fe9f",
    "metadata": {},
    "source": [
+    "----\n",
     "**Step 2** Lets chose a different diagnostic, 'surface_temperature' and load both the UM data, as well LFRic data to use as reference grid."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "e8ad3844-5141-42f6-8837-869624e5612d",
    "metadata": {
     "tags": []
@@ -196,20 +188,27 @@
    "id": "a904d0a2",
    "metadata": {},
    "source": [
-    "**Step 3** Create a regridder from 'ESMFAreaWeighted' \\\n",
-    "Then use the regridder to regrid the new UM cube created earlier. Print your result and notice the mesh characterisics."
+    "**Step 3**  \n",
+    "Regrid : rather than just creating a \"scheme\", as we did in Exercise #1, let's make a reusable regridder object.  \n",
+    "Create a regridder from 'ESMFAreaWeighted', then use it to regrid the new UM cube created earlier.  \n",
+    "Print your result and notice the mesh characterisics.\n",
+    "\n",
+    "(hints:  \n",
+    " can be made with `ESMFAreaWeighted().regridder(source, target)` ;  \n",
+    "then regrid onto a target grid(cube) with `regridder(source, target)`  \n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "21a7a914",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "# Continue here..."
+    "# Code here..."
    ]
   },
   {
@@ -217,25 +216,43 @@
    "id": "1e642914-08be-4243-8249-f66b381f0025",
    "metadata": {},
    "source": [
-    "**Step 4** Plot the regridded UM data with PyVista. \\\n",
-    "(hint: before you can do this you will need to convert you mesh to polydata using pv_from_lfric_cube as explained in [Section 03](./Sec_03_Plotting.ipynb))"
+    "**Step 4** Plot the regridded UM data with PyVista.\n",
+    "\n",
+    "(hints:  \n",
+    "convert with `cube_to_polydata`   \n",
+    "either just `.plot()`, or create a `GeoPlotter()` for more control  \n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35702c7a-f5dd-42c0-847e-33067870c167",
+   "id": "4a786115-a75d-4cfe-b0f6-5ee321934d83",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "pv = cube_to_polydata(um_temp_t0)\n",
+    "pv.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ad0681b-95ce-4841-87a8-276b57b9b0b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "1d5d8c0e-2868-4ba2-963d-7a33633d7152",
    "metadata": {},
    "source": [
-    "**Step 5** Plot the native UM data with PyVista. \\\n",
-    "(hint: before you can do this you will need to convert you mesh to polydata using pv_from_um_cube)"
+    "**Step 5** Plot the native UM data with PyVista.  \n",
+    "\n",
+    "(hint: you will need `cube_to_polydata` again)"
    ]
   },
   {
@@ -244,16 +261,23 @@
    "id": "b021e493-4581-48cb-8b4a-e477b4afdfa1",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "737a0625-72d6-4f25-8072-45d0fa12dfb2",
    "metadata": {},
    "source": [
-    "**Step 6** Now we can plot this data side by side \\\n",
-    "(hints: start by using plotter = GeoPlotter(shape=(1,2)), then create your subplots, add your coastlines, add a base layer, and add your mesh) \\\n",
-    "note: PyVista and GeoVista can be slow in jupyter labs, but try and move the plots, look at the poles - you might notice the polar sigularity problem of the lat-lon grid."
+    "**Step 6** Now we can plot this data side by side  \n",
+    "\n",
+    "(hints:  \n",
+    "start by using `plotter = GeoPlotter(shape=(1,2))`,  \n",
+    "then create your subplots, add your coastlines, add a base layer, and add your mesh  \n",
+    ")  \n",
+    "\n",
+    "**Note:** PyVista and GeoVista can be slow in jupyter labs, but try and move the plots, look at the poles - you might notice the polar sigularity problem of the lat-lon grid."
    ]
   },
   {
@@ -262,14 +286,18 @@
    "id": "8a22da6b-ade6-48f8-925f-4fa3a1a62fc3",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "5da63976-8536-4181-862a-aba1138d9914",
    "metadata": {},
    "source": [
-    "**Step 7** In notebook [Section 03](./Sec_03_plotting.ipynb), we see how to use the plotter.camera_position = viewpoint functionality. Try this out with the surface temperature data. "
+    "**Step 7**  \n",
+    "In the notebook [Section 03](./Sec_03_plotting.ipynb), we see how to use the `plotter.camera_position = viewpoint` functionality.  \n",
+    "Try this out with the surface temperature data. "
    ]
   },
   {
@@ -278,15 +306,28 @@
    "id": "7df0c02a-1ee9-4b56-a5ce-41ee228293cd",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Code here..."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "0ee710c4-148d-41a0-8a6d-bdd2acd8912b",
    "metadata": {},
    "source": [
-    "**Finished!?** These two exercises were just the beginning. If you have time try adding some cells below and extract a zonal mean, or try to select a region of data. "
+    "----\n",
+    "**Finished!?**  \n",
+    "These two exercises were just the beginning.  \n",
+    "If you have time try adding some cells below and extract a zonal mean, or try to select a region of data.\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c50c4732-bee7-4e25-bd5a-41f5b61b00b5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/iris-mesh-tutorial/notebooks/answers/06_Exercise_01_answers.ipynb
+++ b/notebooks/iris-mesh-tutorial/notebooks/answers/06_Exercise_01_answers.ipynb
@@ -13,6 +13,48 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4c9b74e-33c2-4b0d-97ae-754c8b8d95b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Notebook warning controls\n",
+    "import warnings\n",
+    "\n",
+    "# Suppress repeated NumPy masked-array casting warnings from sample data loading.\n",
+    "warnings.filterwarnings(\n",
+    "    \"ignore\",\n",
+    "    message=\"invalid value encountered in cast\",\n",
+    "    category=RuntimeWarning,\n",
+    ")\n",
+    "# Suppress Iris legacy date-precision future warning in tutorial output.\n",
+    "warnings.filterwarnings(\n",
+    "    \"ignore\",\n",
+    "    message=\"You are using legacy date precision for Iris units*\",\n",
+    "    category=FutureWarning,\n",
+    ")\n",
+    "\n",
+    "# Use microsecond date precision to align with upcoming Iris default behaviour.\n",
+    "try:\n",
+    "    import iris\n",
+    "    iris.FUTURE.date_microseconds = True\n",
+    "except Exception:\n",
+    "    pass\n",
+    "\n",
+    "# Import cartopy before importing ESMF to avoid a segfault bug.\n",
+    "import cartopy\n",
+    "\n",
+    "# Check that this kernel can run regridding\n",
+    "import importlib.util\n",
+    "import sys\n",
+    "print(\"Kernel Python:\", sys.executable)\n",
+    "assert importlib.util.find_spec(\"ESMF\") or importlib.util.find_spec(\"esmpy\"), \"ESMPy backend missing in this kernel\"\n",
+    "assert importlib.util.find_spec(\"esmf_regrid\"), \"esmf_regrid missing in this kernel\"\n",
+    "print(\"Backend check: OK\")\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "a64c4394-a34d-434f-b46f-b4efa7c23e1d",
    "metadata": {
@@ -55,22 +97,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5d088822-3671-44ae-8f81-27df368a185e",
+   "id": "747ec0af-eed1-463e-8a62-b8d6496b7af1",
    "metadata": {},
    "source": [
-    "The pv_conversions script contains two functions which convert LFRic cubes to pyvista objects. Load these two functions:"
+    "----\n",
+    "NOTE: the [`iris.experimental.geovista.cube_to_polydata`](https://scitools-iris.readthedocs.io/en/v3.15.0/generated/api/iris.experimental.geovista.html#iris.experimental.geovista.cube_to_polydata) function is provided to convert a cube to a pyvista `polydata` object.  We will be using that ..."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1cd00d6a-e10a-4af1-870d-1874cead45c2",
+   "id": "631302e2-639c-46fa-bb72-11d711608cfd",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "from pv_conversions import pv_from_lfric_cube"
+    "from iris.experimental.geovista import cube_to_polydata"
    ]
   },
   {
@@ -91,12 +134,12 @@
    "outputs": [],
    "source": [
     "# Define the location of the data and file names\n",
-    "data_path = '../example_data/'\n",
+    "data_path = '../../example_data/'\n",
     "lfric_path = data_path + 'u-ct674_20210324T0000Z_lf_ugrid.nc'\n",
     "um_path = data_path + 'u-ct674_20210324T0000Z_um_latlon.nc'\n",
     "\n",
     "lfric_psfc = iris.load_cube(lfric_path, 'surface_air_pressure')\n",
-    "print(lfric_rho)"
+    "print(lfric_psfc)"
    ]
   },
   {
@@ -106,7 +149,7 @@
     "tags": []
    },
    "source": [
-    "**Step 4** Select the first timestep from the data so we have a 2D cube"
+    "**Step 3** Select the first timestep from the data so we have a 2D cube"
    ]
   },
   {
@@ -126,7 +169,7 @@
    "id": "fee7cd45-86b3-45a6-a158-811244de2cb0",
    "metadata": {},
    "source": [
-    "**Step 3** Transform the LFRic cube into a pyvista object using one of the functions from pv_conversions"
+    "**Step 4** Transform the LFRic cube into a pyvista object using `cube_to_polydata`"
    ]
   },
   {
@@ -138,7 +181,7 @@
    },
    "outputs": [],
    "source": [
-    "lfric_pv = pv_from_lfric_cube(lfric_psfc_t0)"
+    "lfric_pv = cube_to_polydata(lfric_psfc_t0)"
    ]
   },
   {
@@ -194,20 +237,20 @@
    "id": "b668e1ea-f9cf-4b79-82a0-6b4d8758d7be",
    "metadata": {},
    "source": [
-    "**Step 7** Create a regridder by using ESMFAreaWeighted. Make sure the mesh and grid are the correct way round, consult the regridding section of the notebooks for help."
+    "**Step 7** Create an Iris regrid scheme with  `ESMFAreaWeighted`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2bfa4b13-9675-4b10-88a0-3810c528d476",
+   "id": "95552067-5dd8-4a24-a050-dcc8fbf8919e",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "# Create the regrider\n",
-    "regridder = ESMFAreaWeighted(lfric_psfc_t0, um_psfc)"
+    "# Create the regridder\n",
+    "scheme = ESMFAreaWeighted().regridder(lfric_psfc_t0, um_psfc)"
    ]
   },
   {
@@ -227,7 +270,7 @@
    },
    "outputs": [],
    "source": [
-    "result = regridder(lfric_psfc_t0)\n",
+    "result = lfric_psfc_t0.regrid(um_psfc, scheme)\n",
     "print(result)"
    ]
   },
@@ -329,6 +372,14 @@
     "\n",
     "qplt.plt.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf373387-97e6-4617-b79f-16994968d0b3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/iris-mesh-tutorial/notebooks/answers/07_Exercise_02_answers.ipynb
+++ b/notebooks/iris-mesh-tutorial/notebooks/answers/07_Exercise_02_answers.ipynb
@@ -13,6 +13,48 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b9537bb-8bd3-4c61-9d42-0fe678410c3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Notebook warning controls\n",
+    "import warnings\n",
+    "\n",
+    "# Suppress repeated NumPy masked-array casting warnings from sample data loading.\n",
+    "warnings.filterwarnings(\n",
+    "    \"ignore\",\n",
+    "    message=\"invalid value encountered in cast\",\n",
+    "    category=RuntimeWarning,\n",
+    ")\n",
+    "# Suppress Iris legacy date-precision future warning in tutorial output.\n",
+    "warnings.filterwarnings(\n",
+    "    \"ignore\",\n",
+    "    message=\"You are using legacy date precision for Iris units*\",\n",
+    "    category=FutureWarning,\n",
+    ")\n",
+    "\n",
+    "# Use microsecond date precision to align with upcoming Iris default behaviour.\n",
+    "try:\n",
+    "    import iris\n",
+    "    iris.FUTURE.date_microseconds = True\n",
+    "except Exception:\n",
+    "    pass\n",
+    "\n",
+    "# Import cartopy before importing ESMF to avoid a segfault bug.\n",
+    "import cartopy\n",
+    "\n",
+    "# Check that this kernel can run regridding\n",
+    "import importlib.util\n",
+    "import sys\n",
+    "print(\"Kernel Python:\", sys.executable)\n",
+    "assert importlib.util.find_spec(\"ESMF\") or importlib.util.find_spec(\"esmpy\"), \"ESMPy backend missing in this kernel\"\n",
+    "assert importlib.util.find_spec(\"esmf_regrid\"), \"esmf_regrid missing in this kernel\"\n",
+    "print(\"Backend check: OK\")\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "a75f07af-d4dc-45d2-b417-948d04eff5f1",
    "metadata": {},
@@ -59,23 +101,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69d50af6",
+   "id": "c5a70ce5-e89d-431a-9f2a-20f353940376",
    "metadata": {},
    "source": [
-    "The pv_conversions script contains two functions which convert LFRic cubes to pyvista objects. Load these two functions:"
+    "----\n",
+    "NOTE: the [`iris.experimental.geovista.cube_to_polydata`](https://scitools-iris.readthedocs.io/en/v3.15.0/generated/api/iris.experimental.geovista.html#iris.experimental.geovista.cube_to_polydata) function is provided to convert a cube to a pyvista `polydata` object.  We will be using that ..."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30e5c42d",
+   "id": "99678835-6658-499a-a4c9-263c2e1b01be",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "from pv_conversions import pv_from_lfric_cube\n",
-    "from pv_conversions import pv_from_um_cube"
+    "from iris.experimental.geovista import cube_to_polydata"
    ]
   },
   {
@@ -96,7 +138,7 @@
    "outputs": [],
    "source": [
     "# Define the location of the data and file names\n",
-    "data_path = '../example_data/'\n",
+    "data_path = '../../example_data/'  # NB path is DIFFERENT from original exercise, as examples notebooks are in sub-folder\n",
     "lfric_path = data_path + 'u-ct674_20210324T0000Z_lf_ugrid.nc'\n",
     "um_path = data_path + 'u-ct674_20210324T0000Z_um_latlon.nc'\n",
     "\n",
@@ -111,8 +153,15 @@
    "id": "a904d0a2",
    "metadata": {},
    "source": [
-    "**Step 3** Initialise the regridder `ESMFAreaWeighted` \\\n",
-    "Then use the regridder to regrid the new UM cube created earlier. Print your result and notice the mesh characterisics."
+    "**Step 3**  \n",
+    "Regrid : rather than just creating a \"scheme\", as we did in Exercise #1, let's make a reusable regridder object.  \n",
+    "Create a regridder from 'ESMFAreaWeighted', then use it to regrid the new UM cube created earlier.  \n",
+    "Print your result and notice the mesh characterisics.\n",
+    "\n",
+    "(hints:  \n",
+    " can be made with `ESMFAreaWeighted().regridder(source, target)` ;  \n",
+    "then regrid onto a target grid(cube) with `regridder(source, target)`  \n",
+    ")"
    ]
   },
   {
@@ -124,18 +173,22 @@
    },
    "outputs": [],
    "source": [
-    "g2m_regridder = ESMFAreaWeighted(um_temp_t0, lfric_psfc)\n",
+    "g2m_regridder = ESMFAreaWeighted().regridder(um_temp_t0, lfric_psfc)\n",
     "regridded_um = g2m_regridder(um_temp_t0)\n",
     "print(regridded_um)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1e642914-08be-4243-8249-f66b381f0025",
+   "id": "ebe4c766-fe5a-4be6-bec3-163f98f54fb8",
    "metadata": {},
    "source": [
-    "**Step 4** Plot the regridded UM data with PyVista. \\\n",
-    "(hint: before you can do this you will need to convert you mesh to polydata using pv_from_lfric_cube)"
+    "**Step 4** Plot the regridded UM data with PyVista.\n",
+    "\n",
+    "(hints:  \n",
+    "convert with `cube_to_polydata`   \n",
+    "either just `.plot()`, or create a `GeoPlotter()` for more control  \n",
+    ")"
    ]
   },
   {
@@ -147,7 +200,7 @@
    },
    "outputs": [],
    "source": [
-    "pv = pv_from_lfric_cube(regridded_um)\n",
+    "pv = cube_to_polydata(regridded_um)\n",
     "pv.plot()"
    ]
   },
@@ -157,7 +210,7 @@
    "metadata": {},
    "source": [
     "**Step 5** Plot the native UM data with PyVista. \\\n",
-    "(hint: before you can do this you will need to convert you mesh to polydata using pv_from_um_cube)"
+    "(hint: before you can do this you will need to convert you mesh to polydata using `cube_to_polydata`)"
    ]
   },
   {
@@ -169,7 +222,7 @@
    },
    "outputs": [],
    "source": [
-    "um_pv = pv_from_um_cube(um_temp_t0)\n",
+    "um_pv = cube_to_polydata(um_temp_t0)\n",
     "um_pv.plot()"
    ]
   },

--- a/notebooks/iris-mesh-tutorial/notebooks/support/pv_conversions.py
+++ b/notebooks/iris-mesh-tutorial/notebooks/support/pv_conversions.py
@@ -1,4 +1,9 @@
-"""Utility functions for converting Iris Cubes to PyVista (plottable) objects."""
+"""Utility functions for converting Iris Cubes to PyVista (plottable) objects.
+
+
+NOTE: these are now effectively **obsolete**
+Please *replace* uses with calls to `iris.experimental.geovista.cube_to_polydata`
+"""
 
 from geovista import Transform
 


### PR DESCRIPTION
Various improvments (hopefully!)
 * generally further reworked the 2 example notebooks
 * added more "hints" for use outside the context of the 'main' course
 * used `iris.experimental.geovista.cube_to_polydata` in place of functions from `support/pv_conversions` 
 * replaced the use of a regridder in Ex.1 with a simple scheme.
 * updated all the worked examples + check they work