### PR TITLE
Issue 258 general feedback

### DIFF
--- a/notebooks/iris-mesh-tutorial/notebooks/03_Plotting.ipynb
+++ b/notebooks/iris-mesh-tutorial/notebooks/03_Plotting.ipynb
@@ -72,8 +72,10 @@
     "import warnings\n",
     "import pyvista as pv\n",
     "\n",
-    "# Use static notebook rendering to avoid trame event-loop conflicts in Jupyter.\n",
-    "pv.set_jupyter_backend(\"static\")\n",
+    "# Static rendering is the default because it is reliable across JupyterLab installs.\n",
+    "# Try \"trame\" or \"client\" if your environment supports interactive PyVista output.\n",
+    "PYVISTA_JUPYTER_BACKEND = \"static\"\n",
+    "pv.set_jupyter_backend(PYVISTA_JUPYTER_BACKEND)\n",
     "\n",
     "# GeoVista 0.5.x expects ``_namedtuple`` on this PyVista internal tuple type.\n",
     "# Add a compatibility alias so projected GeoPlotter examples run in this training env.\n",
@@ -223,9 +225,13 @@
    "id": "78700ada-cf22-4d11-a8ac-de7358da7a92",
    "metadata": {},
    "source": [
-    "### Display instant 3D plot\n",
+    "### Display a 3D plot\n",
     "\n",
-    "We can create an interactive plot of a `PolyData` object simply by calling its `.plot()` method. This plot is interactive. Try dragging to rotate, and the mouse scroll-wheel to zoom. To remove a plot output, in a notebook, use \"Clear Output\" from the \"Edit\" menu (or from right-click on the cell)."
+    "PyVista can display notebook plots using different Jupyter backends. This tutorial uses the `static` backend by default because it is the most reliable option across different JupyterLab installations. Static output is a single image, so it cannot be rotated or zoomed.\n",
+    "\n",
+    "If your environment supports interactive PyVista output, try changing `PYVISTA_JUPYTER_BACKEND` near the top of this notebook from `\"static\"` to `\"trame\"` or `\"client\"`, then restart the kernel and rerun the plotting cells. PyVista documents these options in its [Jupyter notebook plotting guide](https://docs.pyvista.org/user-guide/jupyter/index.html) and [Trame Jupyter backend guide](https://docs.pyvista.org/user-guide/jupyter/trame.html). If the viewer hangs or remains blank, change it back to `\"static\"`.\n",
+    "\n",
+    "To remove a plot output, use **Edit -> Clear Outputs** or right-click the cell output and clear it."
    ]
   },
   {
@@ -247,7 +253,7 @@
     }
    ],
    "source": [
-    "pv.plot(jupyter_backend=\"static\")\n"
+    "pv.plot(jupyter_backend=PYVISTA_JUPYTER_BACKEND)\n"
    ]
   },
   {
@@ -332,7 +338,7 @@
     }
    ],
    "source": [
-    "plotter.show(jupyter_backend=\"static\")\n"
+    "plotter.show(jupyter_backend=PYVISTA_JUPYTER_BACKEND)\n"
    ]
   },
   {
@@ -340,7 +346,7 @@
    "id": "f7353ec4-56a9-4726-a7a3-3d2959410daa",
    "metadata": {},
    "source": [
-    "VTK/PyVista doesn't use plot \"types\". Instead, you add meshes to a plotter and can subsequently control the presentation. By default, `plotter.show()` opens an interactive window. You can instead generate static output. In a notebook, you can generate static output with `jupyter_backend='static'`, in a Python session with `interactive=False`.\n"
+    "VTK/PyVista doesn't use plot \"types\". Instead, you add meshes to a plotter and can subsequently control the presentation. In this notebook, the display backend is controlled by `PYVISTA_JUPYTER_BACKEND`, which was set near the top of the notebook.\n"
    ]
   },
   {
@@ -423,7 +429,7 @@
     "new_plotter.add_coastlines()\n",
     "new_plotter.add_mesh(pv, show_edges=True)\n",
     "new_plotter.camera_position = viewpoint\n",
-    "new_plotter.show(jupyter_backend='static')\n"
+    "new_plotter.show(jupyter_backend=PYVISTA_JUPYTER_BACKEND)\n"
    ]
   },
   {
@@ -490,7 +496,7 @@
    "source": [
     "from support.pv_conversions import pv_from_um_cube\n",
     "um_pv = pv_from_um_cube(um_rh)\n",
-    "um_pv.plot(jupyter_backend=\"static\")\n"
+    "um_pv.plot(jupyter_backend=PYVISTA_JUPYTER_BACKEND)\n"
    ]
   },
   {
@@ -526,7 +532,7 @@
    "source": [
     "from support.display_demo_routines import side_by_side_plotter\n",
     "plt = side_by_side_plotter(pv, um_pv)\n",
-    "plt.show(jupyter_backend=\"static\")\n"
+    "plt.show(jupyter_backend=PYVISTA_JUPYTER_BACKEND)\n"
    ]
   },
   {
@@ -565,7 +571,7 @@
     "plotter.add_mesh(pv)\n",
     "# Note: it's important to view down the Z axis\n",
     "plotter.view_xy()\n",
-    "plotter.show(jupyter_backend='static')\n"
+    "plotter.show(jupyter_backend=PYVISTA_JUPYTER_BACKEND)\n"
    ]
   },
   {
@@ -573,7 +579,7 @@
    "id": "79d5eb88-0b72-45bd-842a-cde3449b5c76",
    "metadata": {},
    "source": [
-    "Note these \"2D plots\" are actually flat objects in a 3D space. If you make an interactive plot, you can rotate the panel. The support for projected plotting is still somewhat experimental. Possibly, not all projections will work correctly. Unfortunately, plotter.add_coastlines() does not yet work with projected plots.\n"
+    "Note these \"2D plots\" are actually flat objects in a 3D space. If you use an interactive backend, you can rotate the panel. The support for projected plotting is still somewhat experimental. Possibly, not all projections will work correctly. Unfortunately, plotter.add_coastlines() does not yet work with projected plots.\n"
    ]
   }
  ],

--- a/source/mesh_overview/exercises/practical_exercises.rst
+++ b/source/mesh_overview/exercises/practical_exercises.rst
@@ -154,9 +154,15 @@ Once the environment is set up:
 
       jupyter lab
 
-4. In JupyterLab, select:
+4. In the JupyterLab file browser, open the first tutorial notebook,
+   ``00_Mesh_Tutorial_Intro.ipynb``.
+
+5. With the notebook open, select:
 
    - ``Kernel -> Change Kernel -> Python (lfric-mesh)``
+
+   If JupyterLab asks you to choose a kernel as the notebook opens, select
+   ``Python (lfric-mesh)`` from that dialog instead.
 
 .. important::
    Always launch JupyterLab from within ``notebooks/iris-mesh-tutorial/notebooks`` to ensure paths and imports work correctly.

--- a/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
+++ b/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
@@ -253,25 +253,22 @@ The regridding tools discussed above are documented by the
 Visualising unstructured data
 +++++++++++++++++++++++++++++
 
-In traditional structured grid systems, data is plotted in 2D using
-Matplotlib. Cartopy, a tool used for cartographic elements, assists in this process.
+Structured-grid workflows commonly use Matplotlib for 2D plotting,
+with Cartopy adding map projections and other cartographic features.
+Those tools remain useful for many latitude-longitude datasets, but
+they do not scale well to high-resolution unstructured meshes.
 
-For unstructured grid visualisation, PyVista provides Python access
-to VTK's rendering and mesh-processing capabilities. VTK is a versatile
-toolkit implemented in C++ and can use GPU acceleration for interactive
-rendering. GeoVista adds geospatial and cartographic helpers on top
-of PyVista, performing a role similar to Cartopy for map-aware visualisation.
+The unstructured workflow therefore uses tools built around 3D mesh
+rendering. PyVista provides Python access to the `Visualization Toolkit
+(VTK) <https://vtk.org/>`_, a C++ library for 3D visualisation and mesh
+processing. VTK can use GPU-accelerated rendering, which is important
+for datasets with many mesh faces. GeoVista adds geospatial and
+cartographic helpers on top of PyVista, performing a role similar to
+Cartopy for map-aware visualisation.
 
-While Matplotlib and Cartopy have traditionally been used for
-structured data, these tools do not scale well and struggle to
-handle high-resolution unstructured meshes.
-
-For instance, a C48 mesh has approximately 13,000 faces, and a C1048 mesh (approximately 9.55 km grid spacing at the equator) would require excessive computation and memory resources for Matplotlib and Cartopy. It would take them around 13.5s to render a C48 and 2h for a C1048! With PyVista, a C48 mesh can be rendered in 369 ms, while a C1048 mesh takes 3.87 seconds.
-
-Unstructured visualisation tools include `VTK <https://vtk.org/>`_,
-a GPU-accelerated toolkit for visualisation and mesh processing, and
-`ParaView <https://www.paraview.org/>`_, a parallel visualisation application. PyVista provides a high-level Python interface for VTK, and GeoVista provides
-geospatial helpers for PyVista.
+`ParaView <https://www.paraview.org/>`_ is another tool in this
+ecosystem. It is a parallel visualisation application for large
+scientific datasets.
 
 See the subsections below for detailed package summaries and links.
 
@@ -280,28 +277,33 @@ See the subsections below for detailed package summaries and links.
 PyVista - basics and scope
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-PyVista is an open-source Python library that provides a high-level
-interface to `VTK <https://vtk.org/>`_ (Visualization Toolkit), a
-powerful C++ library for 3D visualisation and mesh processing.
-In the context of LFRic data, PyVista replaces Matplotlib for rendering
-unstructured meshes, delivering GPU-accelerated rendering that
-scales to high-resolution datasets.
+PyVista is the main Python interface used here for rendering LFRic
+unstructured meshes. It gives Scientific Python users a NumPy-friendly
+API for 3D geometry, so they can build visualisation workflows without
+writing C++ code.
 
-PyVista exposes VTK's capabilities through a NumPy-friendly API,
-allowing scientific Python users to work with 3D geometry without
-writing low-level C++ code.
-It supports interactive rendering in Jupyter notebooks as well as
-batch (off-screen) rendering for automated workflows.
-PyVista also provides a rich set of mesh filters, such as slicing,
-contouring, and interpolation, making it suitable for both
-visualisation and computational geometry tasks.
+For the workflows covered in this training, PyVista supports:
 
-The performance advantage of PyVista over Matplotlib becomes
-significant at LFRic resolutions: a C48 mesh (approximately 13,000
-faces) renders in around 370 ms with PyVista, compared to
-approximately 13.5 seconds with Matplotlib, and a C1048 mesh
-renders in under 4 seconds rather than the roughly 2 hours
-Matplotlib would require.
+* interactive rendering in Jupyter notebooks;
+* batch (off-screen) rendering for automated workflows; and
+* mesh filters such as slicing, contouring, and interpolation, which
+  support both visualisation and computational geometry tasks.
+
+The performance advantage over Matplotlib becomes significant at LFRic
+resolutions. For example:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Mesh
+     - PyVista time
+     - Matplotlib time
+   * - C48 (approximately 13,000 faces)
+     - approximately 370 ms
+     - approximately 14 s
+   * - C1048
+     - under 4 s
+     - approximately 2 hours
 
 .. _geovista.basics:
 
@@ -321,6 +323,6 @@ coastline overlays, texture mapping, and regional extraction
 Its current projection support is more limited than
 Cartopy's but includes common geographic rendering workflows
 and selected projected outputs.
-Because GeoVista renders through PyVista and VTK, it benefits from
-the same rendering stack when displaying the high face-counts
-associated with operational LFRic resolutions.
+Because GeoVista uses the same rendering stack as PyVista, it can display
+the high face-count datasets associated with operational LFRic
+resolutions.

--- a/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
+++ b/source/mesh_overview/unstructured/unstructured_introduction/unstructured_introduction.rst
@@ -223,7 +223,13 @@ Different types of regridders are available depending on the source and target g
 
 Each regridder offers various features, including the ability to read and write cubes, perform area-weighted regridding, and preserve metadata during operations. Additionally, the capability to load and save regridders is supported.
 
-For datasets with masked data, the regridding process ensures that the mask is handled correctly. If the mask from the source grid covers more than a specified threshold of a target grid cell, that target cell is included in the mask. Otherwise, it is excluded from the target grid.
+.. admonition:: Masked data during regridding
+
+   Some datasets contain masked data: values that should not be
+   used in analysis. During regridding, the source data mask is carried
+   across to the target grid. If masked source data covers more than the
+   configured threshold for a target cell, that target cell is masked too.
+   Otherwise, the target cell remains unmasked.
 
 Key features of regridding include:
 


### PR DESCRIPTION
## Summary

Addresses learner feedback given in #258 

- Clarifies masked-data handling during regridding by moving the explanation into an admonition.
- Reworks the unstructured visualisation section so VTK, PyVista, GeoVista, and ParaView are introduced in a clearer order with less repetition.
- Updates the JupyterLab kernel-selection instructions so learners first open a notebook before using `Kernel -> Change Kernel`.
- Clarifies that `03_Plotting.ipynb` uses PyVista’s `static` backend by default, adds a shared backend variable, and links to PyVista documentation for `trame` and `client` interactive backends.

I was unsure of one of the sub issues in #258 and so #283 has been created that details just that issue so these changes can be moved forward. 
