### PR TITLE
Add a note about doc8 standards to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# LFRic-Atmosphere-Training
+# ⛈️ LFRic-Atmosphere-Training
 
 This repository hosts the materials for self-learning of the Momentum LFRic Atmosphere. This training is designed to provide an introductory level training for the LFRic Atmospheric model and its associated workflows. The training material includes an overview about the model, development working practices, visualisation of mesh data, LFRic based Science Configurations, and practical exercises for hands-on learning.
 
 The training is structured to cater to users with different levels of expertise, from beginners to advanced users. It covers essential aspects like understanding model input and output files, navigating code repositories, and running model configurations. The goal is to make the training accessible and beneficial for all Momentum users, ensuring they can effectively use the LFRic Atmosphere model.
 
 The LFRic Atmosphere self-learning training can be found at <https://metoffice.github.io/LFRic-Atmosphere-Training>
+
+# 📜 I want to contribute
 
 ## Contributing Guidelines
 
@@ -26,12 +28,31 @@ alongside this one, and is a requirement for contributing to this project.
 Please be aware of and follow the
 [Momentum Code of Conduct.](https://github.com/MetOffice/Momentum/blob/main/docs/CODE_OF_CONDUCT.md)
 
-### Working Practices
+### Written Style and Restructured Text Quality
 
-The preferred way to contribute to LFRic-Atmosphere-Training is to fork the main repository, then submit a "pull request" (PR). When updating this training material, aim for clear and easy-to-understand content. Please keep in mind that this training is intended for an introductory level training.
+When updating this training material, aim for clear and
+easy-to-understand content. Please keep in mind that this training
+is intended for an introductory level training.
+
+The repository's continuous integration runs tests for:
+
+* [PA11y accessibility standards](https://pa11y.org/)
+* [doc8 rst standards](https://doc8.readthedocs.io/readme.html) - you
+  are encouraged to use ``doc8`` before committing changes.
+  [How to check your work](#restructured-text-standards)
+
+
+### Developing Content - How To Guide
+
+#### Version Control
+
+The preferred way to contribute to LFRic-Atmosphere-Training is to
+fork the main repository, then submit a "pull request" (PR).
 
 To [create a fork](https://github.com/MetOffice/LFRic-Atmosphere-Training/fork)
 under your own account. Use the following commands to clone the correct repository and create a `latest` branch pointing to the [`main` branch in this repository](https://github.com/MetOffice/LFRic-Atmosphere-Training/tree/main).
+
+<details><summary>How clone this repository.</summary>
 
 When creating new branches use the `latest` branch as the parent branch unless a feature branch exists.
 
@@ -58,12 +79,16 @@ git remote set-url --push upstream no_push
 git branch -D main
 ```
 
-### Development Environment
+</details>
 
-Dependencies are defined in `pyproject.toml`. There are two possible setup methods, `uv` and `venv` + `pip`, you only need to use one.
+#### Development Environment
 
-#### Route 1: `uv` (recommended)
+Dependencies are defined in `pyproject.toml`. There are two possible
+setup methods, `uv` and `venv` + `pip`, you only need to use one.
 
+Route 1: `uv`
+
+<details><summary>How to use UV to work with this repository.</summary>
 Install `uv` if needed:
 
 ```bash
@@ -100,7 +125,12 @@ source .venv/bin/activate
 
 If you prefer not to activate the environment, run commands with `uv run ...` instead.
 
-#### Route 2: `venv`/`conda` + `pip`
+</details>
+
+Route 2: `venv`/`conda` + `pip`
+
+<details><summary>How to use venv/conda and pip to work with this repository.</summary>
+
 
 Create and activate a virtual environment:
 
@@ -132,16 +162,39 @@ If you are contributing and want an editable install:
 pip install -e ".[notebooks,dev]"
 ```
 
-### Dependency Policy
+</details>
+
+#### Dependency Policy
 
 - Build environments from `pyproject.toml` only.
 - If dependency updates are needed, update constraints in `pyproject.toml` and recreate the environment with your selected setup route.
 
-### Building Training Materials
+#### Restructured Text Standards
 
-The training materials are based on [Sphinx](https://www.sphinx-doc.org) and can be built using the provided Makefile on any desired target format. However, we aim to display the content as HTML pages, and any contributions should ensure these are produced correctly.
+Rather than writing our own list of rules we use
+[doc8 rst standards](https://doc8.readthedocs.io/readme.html).
 
-To build the LFRic Atmosphere training materials in HTML format run the following command:
+You may wish to familiarize yourself with these standards from
+the documentation, but many people find it easier to learn by
+running the doc8 linter on your work:
+
+```console
+doc8 source/
+```
+
+> [!NOTE]
+> doc8 requires you to have installed doc8 with ``pip install -e ".[dev]"``
+> or ``uv sync --extra dev``.
+
+#### Building Training Materials
+
+The training materials are based on [Sphinx](https://www.sphinx-doc.org)
+and can be built using the provided Makefile on any desired target format.
+However, we aim to display the content as HTML pages, and any contributions
+should ensure these are produced correctly.
+
+To build the LFRic Atmosphere training materials in HTML format
+run the following command:
 
 ```bash
 # If you are using uv:
@@ -172,13 +225,13 @@ available run:
 ./etc/bin/intersphinx_reference.py > intersphinx.ref
 ```
 
-### Pull Request (PR) Process
+#### Pull Request (PR) Process
 
 1. Create a well-documented PR with a description of changes.
 1. Request reviews from the [Momentum Partnership Team](mailto:Momentum_Partnership@metoffice.gov.uk) or other maintainers.
 1. Respond to feedback and make changes if required.
 1. Wait for approval and merging.
 
-## Contacts
+# Contacts
 
 If you want to get in contact with us don't hesitate to email the [Momentum Partnership Team](mailto:Momentum_Partnership@metoffice.gov.uk).


### PR DESCRIPTION
* Make it more explicit that we have standards for RST, and that these are just doc8 ones.
* Refactor the section headings
* Put some of the more detailed bits inside `<details>` tags.

[Preview here](https://github.com/wxtim/LFRic-Atmosphere-Training/tree/doc8.code-standards-readme#restructured-text-standards)