### PR TITLE
allowed legal tests to be dispatched by user; removed unresponsive thing

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -2,7 +2,6 @@ name: Legal
 
 on:
   pull_request_target:
-  workflow_dispatch:
 
 jobs:
   cla:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ⛈️ LFRic-Atmosphere-Training
 
-[![Accessibility checks](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/accessibility.yml/badge.svg)](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/accessibility.yml) [![Test documentation](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/tests.yml/badge.svg)](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/tests.yml) [![Legal](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/cla-check.yaml/badge.svg)](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/cla-check.yaml)
+[![Accessibility checks](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/accessibility.yml/badge.svg)](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/accessibility.yml) [![Test documentation](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/tests.yml/badge.svg)](https://github.com/MetOffice/LFRic-Atmosphere-Training/actions/workflows/tests.yml)
 
 
 This repository hosts the materials for self-learning of the Momentum LFRic Atmosphere. This training is designed to provide an introductory level training for the LFRic Atmospheric model and its associated workflows. The training material includes an overview about the model, development working practices, visualisation of mesh data, LFRic based Science Configurations, and practical exercises for hands-on learning.

--- a/source/conf.py
+++ b/source/conf.py
@@ -180,36 +180,6 @@ html_static_path = ['_static']
 html_css_files = ['nav-collapse.css', 'accessibility.css']
 html_js_files = ['nav-collapse.js', 'accessibility.js']
 
-# These URLs are valid learner-facing targets, but cannot be checked reliably
-# from public CI: Cylc Review is an internal hostname and the OASIS site serves
-# an incomplete certificate chain to Python/OpenSSL linkcheck clients.
-linkcheck_ignore = [
-    # an example (but non-existing) link appears in
-    # source/lfric_infrastructure/practical_stem_test.rst
-    'https://github.com/MetOffice/momentum_user_training.example_lfric_workflow/issues/2',
-    # anti-bot checks can intermittently return 415 in CI
-    r'^https?://abilitynet\.org\.uk(?:/.*)?$',
-    # inaccessible from GH Actions, probably anti-bot
-    r'^https?://agupubs\.onlinelibrary\.wiley\.com(?:/.*)?$',
-    # internal to Met Office
-    r'^https?://cylchub(?:/.*)?$',
-    # private repos
-    r'^https?://github\.com/MetOffice/jules(?:/.*)?$',
-    r'^https?://github\.com/MetOffice/LFRic-Atmosphere-Training(?:/.*)?$',
-    # intermittent connection timeouts from GH Actions
-    r'^https?://gitlab\.in2p3\.fr(?:/.*)?$',
-    # opening in Chrome is OK, but in Python it would complain
-    # "unable to get local issuer certificate".
-    # Possibly related to certifi
-    r'^https?://oasis\.cerfacs\.fr(?:/.*)?$',
-    r'^https://www.sciencedirect.com/science/article/pii/S0743731518305306$',
-    r'^https?://code\.metoffice\.gov\.uk(?:/.*)?$',
-    r'https://doi.org/.*',
-    r'https://cirrus.ucsd.edu/ncview/.*',
-    r'https://gitlab.kitware.com/.*',
-    r'https://zenodo.org/.*',
-]
-
 # Add hyperlinks include file to avoid repeated links.
 rst_epilog = open('hyperlinks.rst.include', 'r').read()
 
@@ -229,6 +199,24 @@ intersphinx_mapping = {
     ),
 }
 
-linkcheck_retries = 3    # Retry each link up to 3 times.
-linkcheck_workers = 8    # Set up lots of processes to check links.
-linkcheck_timeout = 10   # Wait 10 seconds before giving up on a site.
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+# #options-for-the-linkcheck-builder
+linkcheck_retries = 3      # Retry each link up to 3 times.
+linkcheck_workers = 8      # Set up lots of processes to check links.
+linkcheck_timeout = 10     # Wait 10 seconds before giving up on a site.
+
+# These URLs are valid learner-facing targets, but cannot be checked reliably:
+linkcheck_ignore = [
+    'https://github.com/MetOffice/momentum_user_training.example_lfric_workflow/issues/2',
+    r'^https?://abilitynet\.org\.uk(?:/.*)?$',
+    r'^https?://agupubs\.onlinelibrary\.wiley\.com(?:/.*)?$',
+    r'^https?://cylchub(?:/.*)?$',
+    r'^https?://gitlab\.in2p3\.fr(?:/.*)?$',
+    r'^https?://oasis\.cerfacs\.fr(?:/.*)?$',
+    r'^https://www.sciencedirect.com/science/article/pii/S0743731518305306$',
+    r'^https?://code\.metoffice\.gov\.uk(?:/.*)?$',
+    r'https://doi.org/.*',
+    r'https://cirrus.ucsd.edu/ncview/.*',
+    r'https://gitlab.kitware.com/.*',
+    r'https://zenodo.org/.*',
+]

--- a/source/conf.py
+++ b/source/conf.py
@@ -206,6 +206,8 @@ linkcheck_ignore = [
     r'^https?://code\.metoffice\.gov\.uk(?:/.*)?$',
     r'https://doi.org/.*',
     r'https://cirrus.ucsd.edu/ncview/.*',
+    r'https://gitlab.kitware.com/.*',
+    r'https://zenodo.org/.*',
 ]
 
 # Add hyperlinks include file to avoid repeated links.
@@ -226,3 +228,7 @@ intersphinx_mapping = {
         'https://psyclone.readthedocs.io/en/stable/', None
     ),
 }
+
+linkcheck_retries = 3    # Retry each link up to 3 times.
+linkcheck_workers = 8    # Set up lots of processes to check links.
+linkcheck_timeout = 10   # Wait 10 seconds before giving up on a site.


### PR DESCRIPTION
* Add a skip for _another_ domain which now has cloudflare style checks breaking linkcheck.
* Modified the linkcheck settings to allow re-runs of failed domains. Might help with flakiness?
* Removed the workflow_dispatch method from the cla-check workflow. Some naughty person added this directly to the repo for testing purposes and it should be reverted. 
* Removed the badge for CLA Check. It will never pass on main because it is looking for variables defining the PR author.
* Commented out the linkcheck skips and manually checked all failures. Removed items which are no longer used.